### PR TITLE
Untested support for "Two Volumes" polygons 

### DIFF
--- a/src/debug_ui.zig
+++ b/src/debug_ui.zig
@@ -537,6 +537,7 @@ pub fn draw(self: *@This(), d: *Deecy) !void {
             }
             if (zgui.collapsingHeader("Modifier Volumes", .{ .frame_padding = true })) {
                 zgui.indent(.{});
+                // NOTE: By the time we get there, the renderer took the volumes for itself (rather than copying them).
                 {
                     const header = try std.fmt.bufPrintZ(&buffer, "Opaque ({d})###OMV", .{d.renderer.opaque_modifier_volumes.items.len});
                     if (zgui.collapsingHeader(header, .{})) {
@@ -545,14 +546,15 @@ pub fn draw(self: *@This(), d: *Deecy) !void {
                         }
                     }
                 }
-                //{
-                //    const header = try std.fmt.bufPrintZ(&buffer, "Translucent ({d})###TMV", .{d.renderer.translucent_modifier_volumes.items.len});
-                //    if (zgui.collapsingHeader(header, .{})) {
-                //        for (d.renderer.translucent_modifier_volumes.items) |vol| {
-                //            zgui.text("  {any}", .{vol});
-                //        }
-                //    }
-                //}
+                // NOTE: Translucent Modifier Volumes are not currently supported by the renderer and thus are not transfered there. We're getting them directly from Holly.
+                {
+                    const header = try std.fmt.bufPrintZ(&buffer, "Translucent ({d})###TMV", .{d.dc.gpu._ta_translucent_modifier_volumes.items.len});
+                    if (zgui.collapsingHeader(header, .{})) {
+                        for (d.dc.gpu._ta_translucent_modifier_volumes.items) |vol| {
+                            zgui.text("  {any}", .{vol});
+                        }
+                    }
+                }
                 zgui.unindent(.{});
             }
 

--- a/src/shaders/fragment_color.wgsl
+++ b/src/shaders/fragment_color.wgsl
@@ -10,22 +10,18 @@
 
 @group(1) @binding(0) var image_sampler: sampler;
 
-fn tex_sample(uv: vec2<f32>, control: u32, index: u32) -> vec4<f32> {
-    var idx = index;
-    if(idx > 255) { idx = 0; }
-    // textureSample can't be called in non-uniform context, because of this derivative, I guess.
-    // This kinda feel like a hack, but works.
-    let ddx = dpdx(uv);
-    let ddy = dpdy(uv);
+fn tex_sample(uv: vec2<f32>, duvdx: vec2<f32>, duvdy: vec2<f32>, control: u32, index: u32) -> vec4<f32> {
+    if(index > 255) { return vec4<f32>(1.0, 0.0, 0.0, 1.0); }
+
     switch(max((control >> 4) & 7, (control >> 7) & 7))  {
-        case 0u: { return textureSampleGrad(texture_array_8x8, image_sampler, uv, idx, ddx, ddy); }
-        case 1u: { return textureSampleGrad(texture_array_16x16, image_sampler, uv, idx, ddx, ddy); }
-        case 2u: { return textureSampleGrad(texture_array_32x32, image_sampler, uv, idx, ddx, ddy); }
-        case 3u: { return textureSampleGrad(texture_array_64x64, image_sampler, uv, idx, ddx, ddy); }
-        case 4u: { return textureSampleGrad(texture_array_128x128, image_sampler, uv, idx, ddx, ddy); }
-        case 5u: { return textureSampleGrad(texture_array_256x256, image_sampler, uv, idx, ddx, ddy); }
-        case 6u: { return textureSampleGrad(texture_array_512x512, image_sampler, uv, idx, ddx, ddy); }
-        case 7u: { return textureSampleGrad(texture_array_1024x1024, image_sampler, uv, idx, ddx, ddy); }
+        case 0u: { return textureSampleGrad(texture_array_8x8, image_sampler, uv, index, duvdx, duvdy); }
+        case 1u: { return textureSampleGrad(texture_array_16x16, image_sampler, uv, index, duvdx, duvdy); }
+        case 2u: { return textureSampleGrad(texture_array_32x32, image_sampler, uv, index, duvdx, duvdy); }
+        case 3u: { return textureSampleGrad(texture_array_64x64, image_sampler, uv, index, duvdx, duvdy); }
+        case 4u: { return textureSampleGrad(texture_array_128x128, image_sampler, uv, index, duvdx, duvdy); }
+        case 5u: { return textureSampleGrad(texture_array_256x256, image_sampler, uv, index, duvdx, duvdy); }
+        case 6u: { return textureSampleGrad(texture_array_512x512, image_sampler, uv, index, duvdx, duvdy); }
+        case 7u: { return textureSampleGrad(texture_array_1024x1024, image_sampler, uv, index, duvdx, duvdy); }
         default: { return vec4<f32>(1.0, 0.0, 0.0, 1.0); } 
     }
 }
@@ -92,18 +88,20 @@ fn area_color(
     base_color: vec4<f32>,
     offset_color: vec4<f32>,
     uv: vec2<f32>,
+    duvdx: vec2<f32>,
+    duvdy: vec2<f32>,
     tex: vec2<u32>,
     inv_w: f32,
     punch_through: bool,
 ) -> vec4<f32> {
-    let u_size: f32 = tex_size((tex[1] >> 4) & 7);
-    let v_size: f32 = tex_size((tex[1] >> 7) & 7);
-    let uv_factor = select(vec2<f32>(1.0, v_size / u_size), vec2<f32>(u_size / v_size, 1.0), u_size < v_size);
-    let tex_color = tex_sample(uv_factor * uv, tex[1], tex[0]);
-
     var final_color = base_color + vec4<f32>(offset_color.rgb, 0.0);
 
     if (tex[1] & 1) == 1 {
+        let u_size: f32 = tex_size((tex[1] >> 4) & 7);
+        let v_size: f32 = tex_size((tex[1] >> 7) & 7);
+        let uv_factor = select(vec2<f32>(1.0, v_size / u_size), vec2<f32>(u_size / v_size, 1.0), u_size < v_size);
+        let tex_color = tex_sample(uv_factor * uv, uv_factor * duvdx, uv_factor * duvdy, tex[1], tex[0]);
+
         let shading = (tex[1] >> 1) & 0x3;
         let ignore_tex_alpha = ((tex[1] >> 3) & 0x1) == 1;
         let tex_a = select(tex_color.a, 1.0, ignore_tex_alpha);
@@ -161,29 +159,35 @@ fn fragment_color(
     inv_w: f32,
     punch_through: bool,
 ) -> FragmentColor {
-    
     var output : FragmentColor;
+    
+    let duvdx = dpdx(uv);
+    let duvdy = dpdy(uv);
+    let area1_duvdx= dpdx(area1_uv);
+    let area1_duvdy= dpdy(area1_uv);
+
     output.area0 = area_color(
         base_color,
         offset_color,
         uv,
+        duvdx,
+        duvdy,
         tex,
-        inv_w,
-        punch_through
-    );
-    
-    // Call must done from a uniform context because of texture loads, can't be conditional.
-    let area1 = area_color(
-        area1_base_color,
-        area1_offset_color,
-        area1_uv,
-        area1_tex,
         inv_w,
         punch_through
     );
 
     if(((tex[1] >> 23) & 1) == 1) { // "Two Volume"
-        output.area1 = area1;
+        output.area1 = area_color(
+            area1_base_color,
+            area1_offset_color,
+            area1_uv,
+            area1_duvdx,
+            area1_duvdy,
+            area1_tex,
+            inv_w,
+            punch_through
+        );
     } else {
         output.area1 = output.area0;
     }

--- a/src/shaders/fragment_color.wgsl
+++ b/src/shaders/fragment_color.wgsl
@@ -11,19 +11,21 @@
 @group(1) @binding(0) var image_sampler: sampler;
 
 fn tex_sample(uv: vec2<f32>, control: u32, index: u32) -> vec4<f32> {
+    var idx = index;
+    if(idx > 255) { idx = 0; }
     // textureSample can't be called in non-uniform context, because of this derivative, I guess.
     // This kinda feel like a hack, but works.
     let ddx = dpdx(uv);
     let ddy = dpdy(uv);
     switch(max((control >> 4) & 7, (control >> 7) & 7))  {
-        case 0u: { return textureSampleGrad(texture_array_8x8, image_sampler, uv, index, ddx, ddy); }
-        case 1u: { return textureSampleGrad(texture_array_16x16, image_sampler, uv, index, ddx, ddy); }
-        case 2u: { return textureSampleGrad(texture_array_32x32, image_sampler, uv, index, ddx, ddy); }
-        case 3u: { return textureSampleGrad(texture_array_64x64, image_sampler, uv, index, ddx, ddy); }
-        case 4u: { return textureSampleGrad(texture_array_128x128, image_sampler, uv, index, ddx, ddy); }
-        case 5u: { return textureSampleGrad(texture_array_256x256, image_sampler, uv, index, ddx, ddy); }
-        case 6u: { return textureSampleGrad(texture_array_512x512, image_sampler, uv, index, ddx, ddy); }
-        case 7u: { return textureSampleGrad(texture_array_1024x1024, image_sampler, uv, index, ddx, ddy); }
+        case 0u: { return textureSampleGrad(texture_array_8x8, image_sampler, uv, idx, ddx, ddy); }
+        case 1u: { return textureSampleGrad(texture_array_16x16, image_sampler, uv, idx, ddx, ddy); }
+        case 2u: { return textureSampleGrad(texture_array_32x32, image_sampler, uv, idx, ddx, ddy); }
+        case 3u: { return textureSampleGrad(texture_array_64x64, image_sampler, uv, idx, ddx, ddy); }
+        case 4u: { return textureSampleGrad(texture_array_128x128, image_sampler, uv, idx, ddx, ddy); }
+        case 5u: { return textureSampleGrad(texture_array_256x256, image_sampler, uv, idx, ddx, ddy); }
+        case 6u: { return textureSampleGrad(texture_array_512x512, image_sampler, uv, idx, ddx, ddy); }
+        case 7u: { return textureSampleGrad(texture_array_1024x1024, image_sampler, uv, idx, ddx, ddy); }
         default: { return vec4<f32>(1.0, 0.0, 0.0, 1.0); } 
     }
 }

--- a/src/shaders/fs.wgsl
+++ b/src/shaders/fs.wgsl
@@ -7,12 +7,18 @@ struct FragmentOutput {
 fn main(
     @location(0) base_color: vec4<f32>,
     @location(1) offset_color: vec4<f32>,
-    @location(2) uv: vec2<f32>,
-    @location(3) inv_w: f32,
+    @location(2) inv_w: f32,
+    @location(3) uv: vec2<f32>,
     @location(4) @interpolate(flat) tex_idx_shading_instr: vec2<u32>,
-    @location(5) @interpolate(flat) index: u32,
-    @location(6) @interpolate(flat) flat_base_color: vec4<f32>,
-    @location(7) @interpolate(flat) flat_offset_color: vec4<f32>,
+    @location(5) area1_base_color: vec4<f32>,
+    @location(6) area1_offset_color: vec4<f32>,
+    @location(7) area1_uv: vec2<f32>,
+    @location(8) @interpolate(flat) area1_tex_idx_shading_instr: vec2<u32>,
+    @location(9) @interpolate(flat) index: u32,
+    @location(10) @interpolate(flat) flat_base_color: vec4<f32>,
+    @location(11) @interpolate(flat) flat_offset_color: vec4<f32>,
+    @location(12) @interpolate(flat) area1_flat_base_color: vec4<f32>,
+    @location(13) @interpolate(flat) area1_flat_offset_color: vec4<f32>,
 ) -> FragmentOutput {
     let gouraud = ((tex_idx_shading_instr[1] >> 23) & 1) == 1;
 
@@ -21,6 +27,10 @@ fn main(
         select(flat_offset_color, offset_color / inv_w, gouraud), 
         uv / inv_w, 
         tex_idx_shading_instr, 
+        select(area1_flat_base_color, area1_base_color / inv_w , gouraud), 
+        select(area1_flat_offset_color, area1_offset_color / inv_w, gouraud), 
+        area1_uv / inv_w, 
+        area1_tex_idx_shading_instr, 
         inv_w, 
         true
     );

--- a/src/shaders/oit_draw_fs.wgsl
+++ b/src/shaders/oit_draw_fs.wgsl
@@ -33,12 +33,18 @@ fn main(
     @builtin(position) position: vec4<f32>,
     @location(0) base_color: vec4<f32>,
     @location(1) offset_color: vec4<f32>,
-    @location(2) uv: vec2<f32>,
-    @location(3) inv_w: f32,
+    @location(2) inv_w: f32,
+    @location(3) uv: vec2<f32>,
     @location(4) @interpolate(flat) tex_idx_shading_instr: vec2<u32>,
-    @location(5) @interpolate(flat) index: u32,
-    @location(6) @interpolate(flat) flat_base_color: vec4<f32>,
-    @location(7) @interpolate(flat) flat_offset_color: vec4<f32>,
+    @location(5) area1_base_color: vec4<f32>,
+    @location(6) area1_offset_color: vec4<f32>,
+    @location(7) area1_uv: vec2<f32>,
+    @location(8) @interpolate(flat) area1_tex_idx_shading_instr: vec2<u32>,
+    @location(9) @interpolate(flat) index: u32,
+    @location(10) @interpolate(flat) flat_base_color: vec4<f32>,
+    @location(11) @interpolate(flat) flat_offset_color: vec4<f32>,
+    @location(12) @interpolate(flat) area1_flat_base_color: vec4<f32>,
+    @location(13) @interpolate(flat) area1_flat_offset_color: vec4<f32>,
 ) {
     let frag_coords = vec2<i32>(position.xy);
     let shading_instructions = tex_idx_shading_instr[1];
@@ -81,6 +87,10 @@ fn main(
         select(flat_offset_color, offset_color / inv_w, gouraud), 
         uv / inv_w, 
         tex_idx_shading_instr, 
+        select(area1_flat_base_color, area1_base_color / inv_w , gouraud), 
+        select(area1_flat_offset_color, area1_offset_color / inv_w, gouraud), 
+        area1_uv / inv_w, 
+        area1_tex_idx_shading_instr, 
         inv_w, 
         false
     );

--- a/src/shaders/vs.wgsl
+++ b/src/shaders/vs.wgsl
@@ -1,15 +1,21 @@
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
  
 struct VertexOut {
-     @builtin(position) position_clip: vec4<f32>,
-     @location(0) base_color: vec4<f32>,
-     @location(1) offset_color: vec4<f32>,
-     @location(2) uv: vec2<f32>,
-     @location(3) inv_w: f32,
-     @location(4) @interpolate(flat) tex_idx_shading_instr: vec2<u32>,
-     @location(5) @interpolate(flat) index: u32,
-     @location(6) @interpolate(flat) flat_base_color: vec4<f32>, // Probably not the best use of bandwidth, but this beats using a separate pass/shader combination for now. 
-     @location(7) @interpolate(flat) flat_offset_color: vec4<f32>,
+    @builtin(position) position_clip: vec4<f32>,
+    @location(0) base_color: vec4<f32>,
+    @location(1) offset_color: vec4<f32>,
+    @location(2) inv_w: f32,
+    @location(3) uv: vec2<f32>,
+    @location(4) @interpolate(flat) tex_idx_shading_instr: vec2<u32>,
+    @location(5) area1_base_color: vec4<f32>,
+    @location(6) area1_offset_color: vec4<f32>,
+    @location(7) area1_uv: vec2<f32>,
+    @location(8) @interpolate(flat) area1_tex_idx_shading_instr: vec2<u32>,
+    @location(9) @interpolate(flat) index: u32,
+    @location(10) @interpolate(flat) flat_base_color: vec4<f32>, // Probably not the best use of bandwidth, but this beats using a separate pass/shader combination for now. 
+    @location(11) @interpolate(flat) flat_offset_color: vec4<f32>,
+    @location(12) @interpolate(flat) area1_flat_base_color: vec4<f32>,
+    @location(13) @interpolate(flat) area1_flat_offset_color: vec4<f32>,
  }
 
 @vertex
@@ -19,6 +25,10 @@ fn main(
     @location(2) offset_color: vec4<f32>,
     @location(3) uv: vec2<f32>,
     @location(4) tex_idx_shading_instr: vec2<u32>, // Texture index and Texture control word
+    @location(5) area1_base_color: vec4<f32>,
+    @location(6) area1_offset_color: vec4<f32>,
+    @location(7) area1_uv: vec2<f32>,
+    @location(8) area1_tex_idx_shading_instr: vec2<u32>,
     @builtin(vertex_index) vertex_index: u32,
 ) -> VertexOut {
     var output: VertexOut;
@@ -42,14 +52,23 @@ fn main(
     output.base_color = inv_w * base_color;
     output.offset_color = inv_w * offset_color;
 
-    output.uv = inv_w * uv;
     output.inv_w = inv_w;
+
+    output.uv = inv_w * uv;
     output.tex_idx_shading_instr = tex_idx_shading_instr;
+    
+    
+    output.area1_base_color = inv_w * area1_base_color;
+    output.area1_offset_color = inv_w * area1_offset_color;
+    output.area1_uv = inv_w * area1_uv;
+    output.area1_tex_idx_shading_instr = area1_tex_idx_shading_instr;
 
     output.index = vertex_index;
 
     output.flat_base_color = base_color;
     output.flat_offset_color = offset_color;
+    output.area1_flat_base_color = area1_base_color;
+    output.area1_flat_offset_color = area1_offset_color;
 
     return output;
 }


### PR DESCRIPTION
Speed Devils uses "Two Volumes" polygon (Polygon Type 3, Vertex Parameters Type 11), but doesn't seem to submit any Modifier Volume? This isn't normal, it should have shadows.
Anyway, this means I couldn't verify this implementation, at least I don't think it breaks anything.
But it does make the vertices even bigger.