### PR TITLE
Custom compression for save states

### DIFF
--- a/src/aica.zig
+++ b/src/aica.zig
@@ -1394,6 +1394,10 @@ pub const AICA = struct {
         bytes += try reader.read(std.mem.asBytes(&self._timer_cycles_counter));
         bytes += try reader.read(std.mem.sliceAsBytes(self._timer_counters[0..]));
         bytes += try reader.read(std.mem.asBytes(&self._samples_counter));
+
+        self.sample_read_offset = 0;
+        self.sample_write_offset = 0;
+
         return bytes;
     }
 };

--- a/src/aica.zig
+++ b/src/aica.zig
@@ -1377,6 +1377,11 @@ pub const AICA = struct {
         bytes += try writer.write(std.mem.asBytes(&self._timer_cycles_counter));
         bytes += try writer.write(std.mem.sliceAsBytes(self._timer_counters[0..]));
         bytes += try writer.write(std.mem.asBytes(&self._samples_counter));
+
+        bytes += try writer.write(std.mem.sliceAsBytes(self.sample_buffer[0..]));
+        bytes += try writer.write(std.mem.asBytes(&self.sample_read_offset));
+        bytes += try writer.write(std.mem.asBytes(&self.sample_write_offset));
+
         return bytes;
     }
 
@@ -1395,8 +1400,9 @@ pub const AICA = struct {
         bytes += try reader.read(std.mem.sliceAsBytes(self._timer_counters[0..]));
         bytes += try reader.read(std.mem.asBytes(&self._samples_counter));
 
-        self.sample_read_offset = 0;
-        self.sample_write_offset = 0;
+        bytes += try reader.read(std.mem.sliceAsBytes(self.sample_buffer[0..]));
+        bytes += try reader.read(std.mem.asBytes(&self.sample_read_offset));
+        bytes += try reader.read(std.mem.asBytes(&self.sample_write_offset));
 
         return bytes;
     }

--- a/src/aica.zig
+++ b/src/aica.zig
@@ -1378,9 +1378,14 @@ pub const AICA = struct {
         bytes += try writer.write(std.mem.sliceAsBytes(self._timer_counters[0..]));
         bytes += try writer.write(std.mem.asBytes(&self._samples_counter));
 
-        bytes += try writer.write(std.mem.sliceAsBytes(self.sample_buffer[0..]));
         bytes += try writer.write(std.mem.asBytes(&self.sample_read_offset));
         bytes += try writer.write(std.mem.asBytes(&self.sample_write_offset));
+        if (self.sample_read_offset > self.sample_write_offset) {
+            bytes += try writer.write(std.mem.sliceAsBytes(self.sample_buffer[0..self.sample_write_offset]));
+            bytes += try writer.write(std.mem.sliceAsBytes(self.sample_buffer[self.sample_read_offset..]));
+        } else {
+            bytes += try writer.write(std.mem.sliceAsBytes(self.sample_buffer[self.sample_read_offset..self.sample_write_offset]));
+        }
 
         return bytes;
     }
@@ -1400,9 +1405,14 @@ pub const AICA = struct {
         bytes += try reader.read(std.mem.sliceAsBytes(self._timer_counters[0..]));
         bytes += try reader.read(std.mem.asBytes(&self._samples_counter));
 
-        bytes += try reader.read(std.mem.sliceAsBytes(self.sample_buffer[0..]));
         bytes += try reader.read(std.mem.asBytes(&self.sample_read_offset));
         bytes += try reader.read(std.mem.asBytes(&self.sample_write_offset));
+        if (self.sample_read_offset > self.sample_write_offset) {
+            bytes += try reader.read(std.mem.sliceAsBytes(self.sample_buffer[0..self.sample_write_offset]));
+            bytes += try reader.read(std.mem.sliceAsBytes(self.sample_buffer[self.sample_read_offset..]));
+        } else {
+            bytes += try reader.read(std.mem.sliceAsBytes(self.sample_buffer[self.sample_read_offset..self.sample_write_offset]));
+        }
 
         return bytes;
     }

--- a/src/compress/BitPacker.zig
+++ b/src/compress/BitPacker.zig
@@ -24,6 +24,8 @@ pub fn BitPacker(comptime _UnderlyingType: type, comptime _ValueType: type, comp
         const Self = @This();
         pub const UnderlyingType = _UnderlyingType;
         pub const ValueType = _ValueType;
+        pub const InitialBitSize = initial_bit_size;
+        pub const ReservedBits = reserved_bits;
 
         pub fn bitsPerItem() u8 {
             return @bitSizeOf(UnderlyingType) - reserved_bits;
@@ -49,9 +51,9 @@ pub fn BitPacker(comptime _UnderlyingType: type, comptime _ValueType: type, comp
         }
 
         // FIXME: This should return a const version of @This()
-        pub fn fromSlice(allocator: std.mem.Allocator, data: []UnderlyingType, size: usize) !@This() {
+        pub fn fromSlice(allocator: std.mem.Allocator, data: []const UnderlyingType, size: usize) !@This() {
             return @This(){
-                .arr = std.ArrayList(UnderlyingType).fromOwnedSlice(allocator, data),
+                .arr = std.ArrayList(UnderlyingType).fromOwnedSlice(allocator, @constCast(data)),
                 .size = size,
                 .size_since_reset = 0,
                 .value_size = 0, // FIXME: This is intended to be read-only. Passing a wrong value on purpose here.

--- a/src/compress/BitPacker.zig
+++ b/src/compress/BitPacker.zig
@@ -1,0 +1,346 @@
+const std = @import("std");
+
+fn BitMasks(comptime T: type) [@bitSizeOf(T) + 1]T {
+    var masks: [@bitSizeOf(T) + 1]T = undefined;
+    masks[0] = 0;
+    for (1..@bitSizeOf(T)) |i| {
+        masks[i] = ~@as(T, 0) >> @intCast(@bitSizeOf(T) - i);
+    }
+    masks[@bitSizeOf(T)] = ~@as(T, 0);
+    return masks;
+}
+
+// initial_bit_size: Determine the initial expected max values.
+// reserved_bits: Skip this number of bits in each array item. Reduces the packer efficiency to produce valid values for your target encoding.
+pub fn BitPacker(comptime _UnderlyingType: type, comptime _ValueType: type, comptime initial_bit_size: u8, comptime reserved_bits: u8) type {
+    return struct {
+        arr: std.ArrayList(UnderlyingType),
+
+        size: usize = 0,
+        size_since_reset: usize = 0,
+        value_size: u8 = initial_bit_size,
+        bit: u8 = reserved_bits, // Current bit position
+
+        const Self = @This();
+        pub const UnderlyingType = _UnderlyingType;
+        pub const ValueType = _ValueType;
+
+        pub fn bitsPerItem() u8 {
+            return @bitSizeOf(UnderlyingType) - reserved_bits;
+        }
+
+        pub fn init(allocator: std.mem.Allocator) !@This() {
+            var r = @This(){
+                .arr = std.ArrayList(UnderlyingType).init(allocator),
+            };
+            try r.arr.append(0);
+            return r;
+        }
+
+        // Initial capacity in number of values (approximate upper bound).
+        pub fn initCapacity(allocator: std.mem.Allocator, initial_capacity: usize) !@This() {
+            const bit_count = @min(@bitSizeOf(ValueType), @as(u7, @intFromFloat(@log2(@as(f32, @floatFromInt(initial_capacity)) + 1))));
+            const capacity_in_underlying_type: u32 = @intCast(1 + (bit_count * initial_capacity + @bitSizeOf(UnderlyingType)) / @bitSizeOf(UnderlyingType));
+            var r = @This(){
+                .arr = try std.ArrayList(UnderlyingType).initCapacity(allocator, capacity_in_underlying_type),
+            };
+            r.arr.appendAssumeCapacity(0);
+            return r;
+        }
+
+        // FIXME: This should return a const version of @This()
+        pub fn fromSlice(allocator: std.mem.Allocator, data: []UnderlyingType, size: usize) !@This() {
+            return @This(){
+                .arr = std.ArrayList(UnderlyingType).fromOwnedSlice(allocator, data),
+                .size = size,
+                .size_since_reset = 0,
+                .value_size = 0, // FIXME: This is intended to be read-only. Passing a wrong value on purpose here.
+            };
+        }
+
+        pub fn unpack(self: @This(), allocator: std.mem.Allocator) ![]const ValueType {
+            var r = try std.ArrayList(ValueType).initCapacity(allocator, self.size);
+            var it = self.iterator();
+            while (it.next()) |v| {
+                r.appendAssumeCapacity(v);
+            }
+            return r.toOwnedSlice();
+        }
+
+        pub fn unpackWithReset(self: @This(), allocator: std.mem.Allocator, sentinel_token: ValueType) ![]const ValueType {
+            var r = try std.ArrayList(ValueType).initCapacity(allocator, self.size);
+            var it = self.iterator();
+            while (it.next()) |v| {
+                r.appendAssumeCapacity(v);
+                if (v == sentinel_token) {
+                    it.resetValueSize();
+                }
+            }
+            return r.toOwnedSlice();
+        }
+
+        pub fn deinit(self: *@This()) void {
+            self.arr.deinit();
+        }
+
+        pub fn resetValueSize(self: *@This()) void {
+            self.value_size = initial_bit_size;
+            self.size_since_reset = 0;
+        }
+
+        pub fn append(self: *@This(), value: ValueType) !void {
+            // We're being conservative here. Prefer using appendAssumeCapacity directly.
+            if (self.bit + self.value_size + 1 >= @bitSizeOf(UnderlyingType))
+                try self.arr.ensureTotalCapacity(self.arr.items.len + 1);
+            self.appendAssumeCapacity(value);
+        }
+
+        pub fn appendAssumeCapacity(self: *@This(), value: ValueType) void {
+            if (self.value_size < @bitSizeOf(ValueType) and self.size_since_reset + (comptime std.math.pow(usize, 2, @max(0, initial_bit_size - 1))) >= (@as(u32, 1) << @intCast(self.value_size)) - 1) {
+                self.value_size += 1;
+            }
+
+            std.debug.assert(self.value_size <= @bitSizeOf(ValueType));
+            std.debug.assert(self.value_size == @bitSizeOf(ValueType) or (value >> @intCast(self.value_size)) == 0);
+
+            // We know a value cannot span more than two underlying items.
+            if (comptime (@bitSizeOf(ValueType) <= @bitSizeOf(UnderlyingType) - reserved_bits)) {
+                const available_bits = @bitSizeOf(UnderlyingType) - self.bit;
+                if (self.value_size <= available_bits) {
+                    self.arr.items[self.arr.items.len - 1] |= @as(UnderlyingType, @intCast(value)) << @truncate(@bitSizeOf(UnderlyingType) - (self.value_size + self.bit));
+                    self.bit += self.value_size;
+                } else {
+                    if (available_bits > 0)
+                        self.arr.items[self.arr.items.len - 1] |= value >> @intCast(self.value_size - available_bits);
+                    const shifted = @as(UnderlyingType, @intCast(value)) << @intCast(@bitSizeOf(UnderlyingType) - (self.value_size - available_bits));
+                    self.arr.appendAssumeCapacity(shifted >> reserved_bits);
+                    self.bit = reserved_bits + self.value_size - available_bits;
+                }
+            } else {
+                var remaining_bits = self.value_size;
+                while (remaining_bits > 0) {
+                    if (self.bit == @bitSizeOf(UnderlyingType)) {
+                        self.arr.appendAssumeCapacity(0);
+                        self.bit = reserved_bits;
+                    }
+
+                    const to_write = @min(remaining_bits, @bitSizeOf(UnderlyingType) - self.bit);
+
+                    var shifted: ValueType = value << @intCast(@bitSizeOf(ValueType) - remaining_bits); // "Mask" high bits
+                    shifted >>= @intCast(self.bit + (@bitSizeOf(ValueType) - @bitSizeOf(UnderlyingType)));
+                    self.arr.items[self.arr.items.len - 1] |= @intCast(shifted);
+
+                    remaining_bits -= to_write;
+
+                    self.bit += to_write;
+                }
+            }
+
+            self.size += 1;
+            self.size_since_reset += 1;
+        }
+
+        const Iterator = struct {
+            bp: *const Self,
+
+            index: usize,
+            index_since_reset: usize,
+            arr_index: usize,
+            bit: u8,
+            value_size: u8,
+
+            pub fn resetValueSize(self: *@This()) void {
+                self.value_size = initial_bit_size;
+                self.index_since_reset = 0;
+            }
+
+            pub fn next(self: *@This()) ?ValueType {
+                if (self.index >= self.bp.size) return null;
+
+                if (self.value_size < @bitSizeOf(ValueType) and self.index_since_reset + (comptime std.math.pow(usize, 2, @max(0, initial_bit_size - 1))) >= (@as(u32, 1) << @intCast(self.value_size)) - 1) {
+                    self.value_size += 1;
+                }
+
+                self.index += 1;
+                self.index_since_reset += 1;
+
+                if (@bitSizeOf(UnderlyingType) - reserved_bits > @bitSizeOf(ValueType)) {
+                    // Here, we now we'll extract the value from at most 2 underlying items.
+                    const available_bits = (@bitSizeOf(UnderlyingType) - self.bit);
+                    if (self.value_size <= available_bits) { // Single item case
+                        const output: ValueType = @truncate((self.bp.arr.items[self.arr_index] >> @intCast(available_bits - self.value_size)) & (comptime BitMasks(ValueType))[self.value_size]);
+                        if (available_bits == self.value_size) {
+                            self.arr_index += 1;
+                            self.bit = reserved_bits;
+                        } else self.bit += self.value_size;
+                        return output;
+                    } else {
+                        const next_bits = self.value_size - available_bits;
+                        var output: ValueType = @truncate((self.bp.arr.items[self.arr_index] & (comptime BitMasks(ValueType))[available_bits]) << @intCast(next_bits));
+                        output |= @truncate((self.bp.arr.items[self.arr_index + 1] >> @intCast(@bitSizeOf(UnderlyingType) - (reserved_bits + next_bits))) & (comptime BitMasks(ValueType))[next_bits]);
+                        self.arr_index += 1;
+                        self.bit = reserved_bits + next_bits;
+                        return output;
+                    }
+                } else {
+                    var output: ValueType = 0;
+                    var remaining_bits = self.value_size;
+                    while (remaining_bits > 0) {
+                        if (self.bit == @bitSizeOf(UnderlyingType)) {
+                            self.arr_index += 1;
+                            self.bit = reserved_bits;
+                        }
+
+                        const to_output = @min(remaining_bits, @bitSizeOf(UnderlyingType) - self.bit);
+                        var shifted = self.bp.arr.items[self.arr_index] << @intCast(self.bit); // "Mask" upper bits
+                        shifted >>= @intCast(@bitSizeOf(UnderlyingType) - to_output); // "Mask" lower bits
+                        output |= @as(ValueType, @intCast(shifted)) << @intCast(remaining_bits - to_output);
+                        remaining_bits -= to_output;
+                        self.bit += to_output;
+                    }
+                    return output;
+                }
+            }
+        };
+
+        pub fn iterator(self: *const @This()) Iterator {
+            return Iterator{
+                .bp = self,
+                .index = 0,
+                .index_since_reset = 0,
+                .arr_index = 0,
+                .bit = reserved_bits,
+                .value_size = initial_bit_size,
+            };
+        }
+    };
+}
+
+// NOTE: (/FIXME) 'expected' and 'actual' are flipped in all these expectEqual calls. Type isn't coerced correctly otherwise, and I'd rather have a weird error message than writing a workaround for that right now.
+
+test "basics" {
+    var bp = try BitPacker(u16, u16, 3, 0).init(std.testing.allocator);
+    defer bp.deinit();
+
+    try bp.append(2);
+    try std.testing.expectEqual(bp.arr.items[0], 2 << @intCast(16 - 3));
+    try std.testing.expectEqual(bp.bit, 3);
+
+    try bp.append(3);
+    try std.testing.expectEqual(bp.arr.items[0], (2 << @intCast(16 - 3)) | (3 << @intCast(16 - 3 * 2)));
+    try std.testing.expectEqual(bp.bit, 6);
+
+    var it = bp.iterator();
+    try std.testing.expectEqual(it.next(), 2);
+    try std.testing.expectEqual(it.next(), 3);
+}
+
+test "reserved bits" {
+    const reserved_bits = 1;
+    var bp = try BitPacker(u16, u16, 3, reserved_bits).init(std.testing.allocator);
+    defer bp.deinit();
+
+    try bp.append(2);
+    try std.testing.expectEqual(bp.arr.items[0], 2 << @intCast(16 - 3 - reserved_bits));
+    try std.testing.expectEqual(bp.bit, 3 + reserved_bits);
+
+    try bp.append(3);
+    try std.testing.expectEqual(bp.arr.items[0], (2 << @intCast(16 - 3 - reserved_bits)) | (3 << @intCast(16 - 3 * 2 - reserved_bits)));
+    try std.testing.expectEqual(bp.bit, 6 + reserved_bits);
+
+    var it = bp.iterator();
+    try std.testing.expectEqual(it.next(), 2);
+    try std.testing.expectEqual(it.next(), 3);
+}
+
+test "incrementing bit size" {
+    var bp = try BitPacker(u16, u16, 3, 0).init(std.testing.allocator);
+    defer bp.deinit();
+
+    for (0..64) |v| {
+        try bp.append(@intCast(v));
+    }
+
+    var it = bp.iterator();
+    for (0..64) |v| {
+        try std.testing.expectEqual(it.next(), @as(u16, @intCast(v)));
+    }
+}
+
+test "incrementing bit size and reserved bits" {
+    var bp = try BitPacker(u16, u16, 3, 1).init(std.testing.allocator);
+    defer bp.deinit();
+
+    for (0..64) |v| {
+        try bp.append(@intCast(v));
+    }
+
+    // Make sure the reserved bit is unset
+    for (bp.arr.items) |v| {
+        try std.testing.expectEqual(v >> 15, 0);
+    }
+
+    var it = bp.iterator();
+    for (0..64) |v| {
+        try std.testing.expectEqual(it.next(), @as(u16, @intCast(v)));
+    }
+}
+
+test "initial_bit_size(2) and reserved_bits(0)" {
+    var bp = try BitPacker(u16, u16, 2, 0).init(std.testing.allocator);
+    defer bp.deinit();
+
+    for (0..32768) |v| {
+        try bp.append(@intCast(v));
+    }
+
+    var it = bp.iterator();
+    for (0..32768) |v| {
+        try std.testing.expectEqual(it.next(), @as(u16, @intCast(v)));
+    }
+}
+
+test "initial_bit_size(9) and reserved_bits(1)" {
+    var bp = try BitPacker(u16, u16, 9, 1).init(std.testing.allocator);
+    defer bp.deinit();
+
+    for (0..32768) |v| {
+        try bp.append(@intCast(v));
+    }
+
+    // Make sure the reserved bit is unset
+    for (bp.arr.items) |v| {
+        try std.testing.expectEqual(v >> 15, 0);
+    }
+
+    var it = bp.iterator();
+    for (0..32768) |v| {
+        try std.testing.expectEqual(it.next(), @as(u16, @intCast(v)));
+    }
+}
+
+test "underlying_type(u16), value_type(u32), initial_bit_size(9) and reserved_bits(1)" {
+    var bp = try BitPacker(u16, u32, 9, 1).init(std.testing.allocator);
+    defer bp.deinit();
+
+    for (0..131072) |v| {
+        try bp.append(@intCast(v));
+    }
+
+    // Make sure the reserved bit is unset
+    for (bp.arr.items) |v| {
+        try std.testing.expectEqual(v >> 15, 0);
+    }
+
+    var it = bp.iterator();
+    for (0..131072) |v| {
+        try std.testing.expectEqual(it.next(), @as(u32, @intCast(v)));
+    }
+
+    const unpacked = try bp.unpack(std.testing.allocator);
+    defer std.testing.allocator.free(unpacked);
+
+    for (unpacked) |v| {
+        try std.testing.expectEqual(v, @as(u32, @intCast(v)));
+    }
+}

--- a/src/compress/Context.zig
+++ b/src/compress/Context.zig
@@ -1,0 +1,95 @@
+const std = @import("std");
+
+// Basic Hash Map implementation using linear probing and fixed power of two capacity.
+// No deletion, no resizing, no rehashing.
+pub fn Context(comptime V: type) type {
+    return struct {
+        const Self = @This();
+        const Hash = u64;
+
+        const Entry = packed struct(u8) {
+            used: bool = false,
+            hash_high: u7 = undefined, // Used as a 'fast' equality check, before comparing the keys. In practice, this doesn't seem to make much of a difference, but neither does reducing the size of entries to a single bit.
+        };
+
+        entries: []Entry,
+        keys: [][]const u8,
+        values: []V,
+        mask: usize, // Capacity mask. Used to quickly calculate the modulo.
+
+        allocator: std.mem.Allocator,
+
+        pub inline fn initCapacity(allocator: std.mem.Allocator, capacity: usize) !Self {
+            std.debug.assert(capacity < (std.math.maxInt(usize) >> 1));
+            // Use next power of two for our capacity. This way we can simplify the modulo using a bitwise and.
+            var c: usize = @as(usize, 1) << @intCast(@min(@bitSizeOf(usize) - 1, (@bitSizeOf(usize) - @clz(capacity))));
+            // Make extra sure we won't come too close to the capacity limit.
+            if (@clz(c) > 0 and @as(f32, @floatFromInt(c)) / @as(f32, @floatFromInt(capacity)) < 1.2) c <<= 1;
+            var r = Self{
+                .entries = try allocator.alloc(Entry, c),
+                .keys = try allocator.alloc([]const u8, c),
+                .values = try allocator.alloc(V, c),
+                .mask = c - 1,
+                .allocator = allocator,
+            };
+            r.clearRetainingCapacity();
+            return r;
+        }
+
+        pub inline fn deinit(self: *Self) void {
+            self.allocator.free(self.values);
+            self.allocator.free(self.keys);
+            self.allocator.free(self.entries);
+        }
+
+        inline fn hash(s: []const u8) Hash {
+            return std.hash.CityHash64.hash(s);
+        }
+
+        inline fn extractHashHigh(h: Hash) u7 {
+            return @truncate(h >> (@bitSizeOf(Hash) - @bitSizeOf(u7)));
+        }
+
+        fn eql(a: []const u8, b: []const u8) bool {
+            if (a.len != b.len) return false;
+            const vec_size = 4;
+            for (0..a.len / vec_size) |i| {
+                const l: @Vector(vec_size, u8) = a[i * vec_size ..][0..vec_size].*;
+                const r: @Vector(vec_size, u8) = b[i * vec_size ..][0..vec_size].*;
+                if (@reduce(.Or, l != r)) return false;
+            }
+            for (a.len - a.len % vec_size..a.len) |i| {
+                if (a[i] != b[i]) return false;
+            }
+            return true;
+        }
+
+        pub inline fn get(self: *Self, key: []const u8) ?V {
+            const h = hash(key);
+            const index = h & self.mask;
+            var i: usize = @intCast(index);
+            const entry: u8 = @bitCast(Entry{ .used = true, .hash_high = extractHashHigh(h) });
+            while (self.entries[i].used) : (i = (i + 1) & self.mask) {
+                if (@as(u8, @bitCast(self.entries[i])) == entry and eql(key, self.keys[i]))
+                    return self.values[i];
+            }
+            return null;
+        }
+
+        pub fn putAssumeCapacityNoClobber(self: *Self, key: []const u8, value: V) void {
+            const h = hash(key);
+            const index = h & self.mask;
+            var i: usize = @intCast(index);
+            while (self.entries[i].used) : (i = (i + 1) & self.mask) {
+                std.debug.assert(!eql(key, self.keys[i]));
+            }
+            self.entries[i] = .{ .used = true, .hash_high = extractHashHigh(h) };
+            self.keys[i] = key;
+            self.values[i] = value;
+        }
+
+        pub inline fn clearRetainingCapacity(self: *Self) void {
+            @memset(self.entries, .{});
+        }
+    };
+}

--- a/src/compress/lzw.zig
+++ b/src/compress/lzw.zig
@@ -1,0 +1,187 @@
+const std = @import("std");
+
+const Context = @import("Context.zig");
+const bp = @import("./BitPacker.zig");
+
+pub const BitPacker = bp.BitPacker(u64, u20, 9, 0);
+
+pub fn compress(data: []const u8, allocator: std.mem.Allocator) !BitPacker {
+    if (data.len == 0) return BitPacker.init(allocator);
+
+    const first_allocated_token: BitPacker.ValueType = comptime std.math.maxInt(u8) + 1;
+    var next_value: BitPacker.ValueType = first_allocated_token;
+    var context = try Context.Context(BitPacker.ValueType).initCapacity(allocator, @as(usize, @min(std.math.maxInt(BitPacker.ValueType), data.len)));
+    defer context.deinit();
+
+    // Max string length in dictionary based on its first character.
+    var max_length: [256]u16 = undefined;
+    @memset(&max_length, 1);
+
+    var output = try BitPacker.initCapacity(allocator, data.len);
+
+    var i: usize = 0;
+    while (true) {
+        const d = data[i..];
+        var curr_len: usize = 1;
+        var prev_value: BitPacker.ValueType = (@as(BitPacker.ValueType, @intCast(d[0])));
+
+        var max: usize = @min(d.len, max_length[d[0]]);
+        // Binary search for the largest string in context
+        while (max > curr_len + 1) {
+            const mid: usize = curr_len + (max - curr_len) / 2;
+            if (context.get(d[0..mid])) |value| {
+                curr_len = mid;
+                prev_value = value;
+            } else {
+                max = mid - 1;
+            }
+        }
+
+        if (curr_len < max) {
+            if (context.get(d[0..max])) |value| {
+                prev_value = value;
+                curr_len = max;
+            }
+        }
+
+        output.appendAssumeCapacity(prev_value);
+        i += curr_len;
+
+        if (curr_len >= d.len - 1) break;
+
+        if (next_value != std.math.maxInt(BitPacker.ValueType)) {
+            const str = d[0 .. curr_len + 1];
+            max_length[str[0]] = @max(max_length[str[0]], @as(u16, @intCast(str.len)));
+            context.putAssumeCapacityNoClobber(str, next_value);
+            next_value += 1;
+        } else {
+            // Restart compression from here with a fresh context
+            context.clearRetainingCapacity();
+            @memset(&max_length, 1);
+            // Insert special token signifying a context reset for decompression.
+            output.appendAssumeCapacity(std.math.maxInt(BitPacker.ValueType));
+
+            output.resetValueSize();
+
+            next_value = first_allocated_token;
+        }
+    }
+
+    // Handle the (potentially) last unencoded byte.
+    if (i < data.len) {
+        std.debug.assert(i == data.len - 1);
+        output.appendAssumeCapacity(@intCast(data[i]));
+    }
+
+    return output;
+}
+
+pub fn decompress(comptime TokenType: type, comptime reserved_codepoints: TokenType, comptime sentinel_token: TokenType, data: []const TokenType, expected_output_size: usize, allocator: std.mem.Allocator) !std.ArrayList(u8) {
+    if (data.len == 0) return std.ArrayList(u8).init(allocator);
+
+    const first_allocated_token: TokenType = comptime std.math.maxInt(u8) + 1 + reserved_codepoints;
+    var next_value: TokenType = first_allocated_token;
+    var context = try std.ArrayList(?[]const u8).initCapacity(allocator, @min(std.math.maxInt(TokenType), first_allocated_token + data.len));
+    defer context.deinit();
+    context.appendNTimesAssumeCapacity(null, context.capacity);
+
+    var output = try std.ArrayList(u8).initCapacity(allocator, expected_output_size);
+    output.appendAssumeCapacity(@intCast(data[0] - reserved_codepoints));
+
+    context.items[data[0]] = output.items[0..1];
+
+    var prev_start: usize = 0;
+    var i: usize = 1;
+    while (i < data.len) {
+        const v = data[i];
+        const new_start = output.items.len;
+
+        if (v != sentinel_token) {
+            if (v < first_allocated_token) {
+                output.appendAssumeCapacity(@intCast(v - reserved_codepoints));
+            } else {
+                if (context.items[v]) |str| {
+                    output.appendSliceAssumeCapacity(str);
+                } else {
+                    // I think the only case where this might happen, is repeating characters.
+                    // For example, 'aaaa' will be encoded as [129, 288, 129], with 288 representing 'aa'.
+                    // However the decoder will never have encountered 'aa' before.
+                    output.appendSliceAssumeCapacity(output.items[prev_start..new_start]);
+                    output.appendAssumeCapacity(output.items[prev_start]);
+                }
+            }
+
+            //                          equivalent to concat(prev_str, str[0])
+            context.items[next_value] = output.items[prev_start .. new_start + 1];
+            next_value += 1;
+        } else {
+            i += 1; // Skip special reset token
+            if (i >= data.len) break;
+            // Reinitialize state
+            next_value = first_allocated_token;
+            context.clearRetainingCapacity();
+            context.appendNTimesAssumeCapacity(null, context.capacity);
+            try std.testing.expect(data[i] < first_allocated_token);
+            output.appendAssumeCapacity(@intCast(data[i] - reserved_codepoints));
+        }
+
+        prev_start = new_start;
+        i += 1;
+    }
+
+    return output;
+}
+
+fn testRound(str: []const u8) !void {
+    var compressed = try compress(str, std.testing.allocator);
+    defer compressed.deinit();
+    const unpacked_data = try compressed.unpackWithReset(std.testing.allocator, std.math.maxInt(BitPacker.ValueType));
+    defer std.testing.allocator.free(unpacked_data);
+    const decompressed = try decompress(BitPacker.ValueType, 0, std.math.maxInt(BitPacker.ValueType), unpacked_data, str.len, std.testing.allocator);
+    defer decompressed.deinit();
+    try std.testing.expectEqualSlices(u8, str, decompressed.items);
+}
+
+test "basic" {
+    try testRound("");
+    try testRound("a");
+    try testRound("aa");
+    try testRound("aaaa");
+    try testRound("aaaaaa");
+    try testRound("aabbaaccaaccaavvbbaaxaaaavwaa");
+    try testRound("1212121");
+    try testRound("3737373");
+    try testRound("3333737370");
+    try testRound("3333737370000000000000000000000");
+    try testRound("12121212");
+    try testRound("37373737");
+    try testRound("33337373737");
+    try testRound("3333737373700000000000000000000");
+    try testRound("3333773737373777777373773737373");
+    try testRound("\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}");
+}
+
+test "fuzzing" {
+    // Doesn't ensure that the string is valid UTF-8, but it should not matter.
+    // Note: In the future, use std.testing.random_seed. See https://github.com/ziglang/zig/issues/17609.
+    const seed = std.crypto.random.int(u64);
+    errdefer std.debug.print("\nFuzzing Test FAILED\n\tSeed: {d}\n", .{seed});
+    var rng = std.rand.DefaultPrng.init(seed);
+    for (0..0) |_| {
+        const length = rng.random().intRangeAtMost(usize, 0, 10_000_000); // Up to ~10MB
+        const str = try std.testing.allocator.alloc(u8, length);
+        defer std.testing.allocator.free(str);
+        rng.fill(str);
+        try testRound(str);
+    }
+}
+
+fn testFile(path: []const u8) !void {
+    const str = try std.fs.cwd().readFileAlloc(std.testing.allocator, path, 1e8);
+    defer std.testing.allocator.free(str);
+    try testRound(str);
+}
+
+test "files" {
+    try testFile("logs/test_save_uncompressed.bin");
+}

--- a/src/compress/lzw.zig
+++ b/src/compress/lzw.zig
@@ -167,7 +167,7 @@ test "fuzzing" {
     const seed = std.crypto.random.int(u64);
     errdefer std.debug.print("\nFuzzing Test FAILED\n\tSeed: {d}\n", .{seed});
     var rng = std.rand.DefaultPrng.init(seed);
-    for (0..0) |_| {
+    for (0..1) |_| {
         const length = rng.random().intRangeAtMost(usize, 0, 10_000_000); // Up to ~10MB
         const str = try std.testing.allocator.alloc(u8, length);
         defer std.testing.allocator.free(str);

--- a/src/deecy.zig
+++ b/src/deecy.zig
@@ -940,7 +940,7 @@ pub const Deecy = struct {
         defer save_slot_path.deinit();
         var file = try std.fs.cwd().createFile(save_slot_path.items, .{});
         defer file.close();
-        _ = try file.write(std.mem.asBytes(&compressed.arr.items.len));
+        _ = try file.write(std.mem.asBytes(&compressed.size));
         _ = try file.write(std.mem.asBytes(&uncompressed_array.items.len));
         std.debug.print("token_count={d}, expected_size={d}\n", .{ compressed.arr.items.len, uncompressed_array.items.len });
         try file.writeAll(std.mem.sliceAsBytes(compressed.arr.items));


### PR DESCRIPTION
Uses the compression algorithm I wrote for https://github.com/Senryoku/smol-string

Produces bigger saves (maybe 25%) and compression is slower, but decompression is waaaaaaay faster, and I think it's the most important metric for this particular application. Instant save state loading feels good. Compression could be offloaded to a separate thread to offset the loss in performance here.