### PR TITLE
[renderer] Handle palettes on the GPU

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -70,7 +70,7 @@ pub fn build(b: *std.Build) void {
         exe.root_module.addImport("zpool", zpool.module("root"));
         exe_check.root_module.addImport("zpool", zpool.module("root"));
 
-        const zgpu = b.dependency("zgpu", .{});
+        const zgpu = b.dependency("zgpu", .{ .max_num_bindings_per_group = 12 });
         exe.root_module.addImport("zgpu", zgpu.module("root"));
         exe.linkLibrary(zgpu.artifact("zdawn"));
         exe_check.root_module.addImport("zgpu", zgpu.module("root"));

--- a/src/holly.zig
+++ b/src/holly.zig
@@ -518,6 +518,13 @@ pub const TextureControlWord = packed struct(u32) {
     pixel_format: TexturePixelFormat = .Reserved,
     vq_compressed: u1 = 0,
     mip_mapped: u1 = 0,
+
+    pub const Mask: u32 = 0xFE1F_FFFF;
+
+    // Mask out reserved bits.
+    pub fn masked(self: @This()) u32 {
+        return @as(u32, @bitCast(self)) & Mask;
+    }
 };
 pub const PaletteTextureControlWord = packed struct(u32) {
     address: u21,

--- a/src/holly.zig
+++ b/src/holly.zig
@@ -525,7 +525,16 @@ pub const TextureControlWord = packed struct(u32) {
     pub fn masked(self: @This()) u32 {
         return @as(u32, @bitCast(self)) & Mask;
     }
+
+    pub fn palette_selector(self: @This()) u10 {
+        return @truncate(switch (self.pixel_format) {
+            .Palette4BPP => (((@as(u32, @bitCast(self)) >> 21) & 0b111111) << 4),
+            .Palette8BPP => (((@as(u32, @bitCast(self)) >> 25) & 0b11) << 8),
+            else => 0,
+        });
+    }
 };
+
 pub const PaletteTextureControlWord = packed struct(u32) {
     address: u21,
     palette_selector: u6,

--- a/src/shaders/fragment_color.wgsl
+++ b/src/shaders/fragment_color.wgsl
@@ -19,14 +19,14 @@ fn tex_sample(uv: vec2<f32>, duvdx: vec2<f32>, duvdy: vec2<f32>, control: u32, i
         var sample = vec4<f32>(0.0);
         // FIXME: Skipping the sampler here also means we don't following the UV mode (clamping/repeating...)
         switch(max((control >> 4) & 7, (control >> 7) & 7))  {
-            case 0u: { sample = textureLoad(texture_array_8x8, vec2<u32>(8 * uv), index, 0); }
-            case 1u: { sample = textureLoad(texture_array_16x16, vec2<u32>(16 * uv), index, 0); }
-            case 2u: { sample = textureLoad(texture_array_32x32, vec2<u32>(32 * uv), index, 0); }
-            case 3u: { sample = textureLoad(texture_array_64x64, vec2<u32>(64 * uv), index, 0); }
-            case 4u: { sample = textureLoad(texture_array_128x128, vec2<u32>(128 * uv), index, 0); }
-            case 5u: { sample = textureLoad(texture_array_256x256, vec2<u32>(256 * uv), index, 0); }
-            case 6u: { sample = textureLoad(texture_array_512x512, vec2<u32>(512 * uv), index, 0); }
-            case 7u: { sample = textureLoad(texture_array_1024x1024, vec2<u32>(1024 * uv), index, 0); }
+            case 0u: { sample = textureSampleLevel(texture_array_8x8, image_sampler, uv, index, 0); }
+            case 1u: { sample = textureSampleLevel(texture_array_16x16, image_sampler, uv, index, 0); }
+            case 2u: { sample = textureSampleLevel(texture_array_32x32, image_sampler, uv, index, 0); }
+            case 3u: { sample = textureSampleLevel(texture_array_64x64, image_sampler, uv, index, 0); }
+            case 4u: { sample = textureSampleLevel(texture_array_128x128, image_sampler, uv, index, 0); }
+            case 5u: { sample = textureSampleLevel(texture_array_256x256, image_sampler, uv, index, 0); }
+            case 6u: { sample = textureSampleLevel(texture_array_512x512, image_sampler, uv, index, 0); }
+            case 7u: { sample = textureSampleLevel(texture_array_1024x1024, image_sampler, uv, index, 0); }
             default: { return vec4<f32>(1.0, 0.0, 0.0, 1.0); } 
         }
         let index = pack4x8unorm(sample.zyxw);

--- a/src/shaders/fragment_color.wgsl
+++ b/src/shaders/fragment_color.wgsl
@@ -7,22 +7,43 @@
 @group(0) @binding(6) var texture_array_256x256: texture_2d_array<f32>;
 @group(0) @binding(7) var texture_array_512x512: texture_2d_array<f32>;
 @group(0) @binding(8) var texture_array_1024x1024: texture_2d_array<f32>;
+@group(0) @binding(10) var<storage, read> palette: array<u32>;
 
 @group(1) @binding(0) var image_sampler: sampler;
 
 fn tex_sample(uv: vec2<f32>, duvdx: vec2<f32>, duvdy: vec2<f32>, control: u32, index: u32) -> vec4<f32> {
     if index >= 512 { return vec4<f32>(1.0, 0.0, 0.0, 1.0); }
 
-    switch(max((control >> 4) & 7, (control >> 7) & 7))  {
-        case 0u: { return textureSampleGrad(texture_array_8x8, image_sampler, uv, index, duvdx, duvdy); }
-        case 1u: { return textureSampleGrad(texture_array_16x16, image_sampler, uv, index, duvdx, duvdy); }
-        case 2u: { return textureSampleGrad(texture_array_32x32, image_sampler, uv, index, duvdx, duvdy); }
-        case 3u: { return textureSampleGrad(texture_array_64x64, image_sampler, uv, index, duvdx, duvdy); }
-        case 4u: { return textureSampleGrad(texture_array_128x128, image_sampler, uv, index, duvdx, duvdy); }
-        case 5u: { return textureSampleGrad(texture_array_256x256, image_sampler, uv, index, duvdx, duvdy); }
-        case 6u: { return textureSampleGrad(texture_array_512x512, image_sampler, uv, index, duvdx, duvdy); }
-        case 7u: { return textureSampleGrad(texture_array_1024x1024, image_sampler, uv, index, duvdx, duvdy); }
-        default: { return vec4<f32>(1.0, 0.0, 0.0, 1.0); } 
+    if ((control >> 25) & 1) == 1 {
+        // Palette Texture
+        var sample = vec4<f32>(0.0);
+        // FIXME: Skipping the sampler here also means we don't following the UV mode (clamping/repeating...)
+        switch(max((control >> 4) & 7, (control >> 7) & 7))  {
+            case 0u: { sample = textureLoad(texture_array_8x8, vec2<u32>(8 * uv), index, 0); }
+            case 1u: { sample = textureLoad(texture_array_16x16, vec2<u32>(16 * uv), index, 0); }
+            case 2u: { sample = textureLoad(texture_array_32x32, vec2<u32>(32 * uv), index, 0); }
+            case 3u: { sample = textureLoad(texture_array_64x64, vec2<u32>(64 * uv), index, 0); }
+            case 4u: { sample = textureLoad(texture_array_128x128, vec2<u32>(128 * uv), index, 0); }
+            case 5u: { sample = textureLoad(texture_array_256x256, vec2<u32>(256 * uv), index, 0); }
+            case 6u: { sample = textureLoad(texture_array_512x512, vec2<u32>(512 * uv), index, 0); }
+            case 7u: { sample = textureLoad(texture_array_1024x1024, vec2<u32>(1024 * uv), index, 0); }
+            default: { return vec4<f32>(1.0, 0.0, 0.0, 1.0); } 
+        }
+        let index = pack4x8unorm(sample.zyxw);
+        // FIXME/TODO: Bilinear filtering!
+        return unpack4x8unorm(palette[index]).zyxw;
+    } else {
+        switch(max((control >> 4) & 7, (control >> 7) & 7))  {
+            case 0u: { return textureSampleGrad(texture_array_8x8, image_sampler, uv, index, duvdx, duvdy); }
+            case 1u: { return textureSampleGrad(texture_array_16x16, image_sampler, uv, index, duvdx, duvdy); }
+            case 2u: { return textureSampleGrad(texture_array_32x32, image_sampler, uv, index, duvdx, duvdy); }
+            case 3u: { return textureSampleGrad(texture_array_64x64, image_sampler, uv, index, duvdx, duvdy); }
+            case 4u: { return textureSampleGrad(texture_array_128x128, image_sampler, uv, index, duvdx, duvdy); }
+            case 5u: { return textureSampleGrad(texture_array_256x256, image_sampler, uv, index, duvdx, duvdy); }
+            case 6u: { return textureSampleGrad(texture_array_512x512, image_sampler, uv, index, duvdx, duvdy); }
+            case 7u: { return textureSampleGrad(texture_array_1024x1024, image_sampler, uv, index, duvdx, duvdy); }
+            default: { return vec4<f32>(1.0, 0.0, 0.0, 1.0); } 
+        }
     }
 }
 


### PR DESCRIPTION
Move palette texture handling to the GPU. This allows to upload only a single copy of the texture (although we're still using 4x the memory for now since it's using the same texture array as regular textures). The palette lookup is now done in a fragment/compute shader within `fragment_color`.
This helps a lot is some games making heavy use of palette swaps for effects.