### PR TITLE
Removed FIXME comment from GDI_SECTOR_OFFSET declaration.

### DIFF
--- a/src/dreamcast/disc/gdi.zig
+++ b/src/dreamcast/disc/gdi.zig
@@ -17,7 +17,7 @@ pub const SectorHeader = extern struct {
     mode: u8,
 };
 
-const GDI_SECTOR_OFFSET = 150; // FIXME: Still unsure about this.
+const GDI_SECTOR_OFFSET = 150;
 
 tracks: std.ArrayList(Track),
 


### PR DESCRIPTION
Removed FIXME comment regarding GDI_SECTOR_OFFSET. This is correct as every CD-Rom/GD-Rom has 150 sectors always as a pregap. These are counted in the sync header as a MSF meaning they canno't be 0 for the first real sector of data.
So Sector is 0 but Absolute sector is already 150.