### PR TITLE
Steam Input enabled (DualSense): small workaround to keep XInput pad bound (ChatGPT-assisted / inspiration only)

### DIFF
--- a/src/deecy_ui.zig
+++ b/src/deecy_ui.zig
@@ -879,9 +879,24 @@ pub fn draw(self: *@This()) !void {
                                             if (available_controllers.items[index].id) |id| {
                                                 if (zgui.selectable(item.name, .{ .selected = d.controllers[port] != null and d.controllers[port].?.id == id }))
                                                     d.controllers[port] = .{ .id = id };
+                                                    d.controllers_forced_none[port] = false;
+                                                    d.config.controllers[port].forced_none = false;
+                                                    // Ensure a physical/virtual controller can't be assigned to multiple ports.
+                                                    // If another port was using the same controller, unbind it and let auto-rebind
+                                                    // pick another available gamepad.
+                                                    for (0..4) |other_port| {
+                                                        if (other_port == port) continue;
+                                                        if (d.controllers[other_port] != null and d.controllers[other_port].?.id == id) {
+                                                            d.controllers[other_port] = null;
+                                                            d.controllers_forced_none[other_port] = false;
+                                                            d.config.controllers[other_port].forced_none = false;
+                                                        }
+                                                    }
                                             } else {
                                                 if (zgui.selectable(item.name, .{ .selected = d.controllers[port] == null }))
                                                     d.controllers[port] = null;
+                                                    d.controllers_forced_none[port] = true;
+                                                    d.config.controllers[port].forced_none = true;
                                             }
                                         }
                                         zgui.endCombo();


### PR DESCRIPTION
**Description**  
Hi! I’m opening this PR mainly to **share an idea / workaround** for Steam Input enabled, not because I’m confident it should be merged as-is.

**Honest disclaimer:** I don’t really know coding (and I’m not comfortable reviewing edge cases). I used **ChatGPT** to help me produce this patch, so please treat it as **inspiration / a starting point**, not a proper contribution.

### What this changes (goal)
When launching Deecy through Steam with **Steam Input enabled** (DualSense → Steam virtual **Xbox 360 / XInput** controller):
- Avoids the controller selection resetting to **None** when Steam recreates/reorders the virtual controller.
- Auto-rebinds a gamepad if the assigned joystick disappears (Steam Input behavior).
- Prevents assigning the **same** controller to two ports (A/B), and `None` can stay `None` instead of instantly rebinding.

### Results on my side
With this build, I can currently play with my DualSense via **Steam Big Picture** with **Steam Input enabled** without issues so far.

### Known remaining issue
Sometimes inputs still don’t work due to **window focus** (Steam/OS focus not on the emulator window). Clicking the emulator window fixes it, with a real mouse or DualSense (hold the PS/Home (Steam) button, move the cursor with the right stick, and use R1 as left click).

**Steam Input disabled is in the same state as master :(**

If you think the direction is useful, feel free to take the idea and implement it properly / in a cleaner way. I’m totally fine if this PR is not merged.
