### PR TITLE
Wayland Resize Fix

### DIFF
--- a/src/deecy.zig
+++ b/src/deecy.zig
@@ -147,18 +147,10 @@ fn glfw_drop_callback(window: *zglfw.Window, count: i32, paths: [*][*:0]const u8
 fn glfw_resize_callback(window: *zglfw.Window, width: i32, height: i32) callconv(.c) void {
     const maybe_app = window.getUserPointer(@This());
     if (maybe_app) |app| {
-        app.gctx_queue_mutex.lockUncancelable(app.io);
-        defer app.gctx_queue_mutex.unlock(app.io);
         if (width > 0 and height > 0) {
-            app.gctx.surface.configure(.{
-                .device = app.gctx.device,
-                .format = zgpu.GraphicsContext.surface_texture_format,
-                .usage = .{ .render_attachment = true },
-                .width = @intCast(width),
-                .height = @intCast(height),
-                .present_mode = app.gctx.present_mode,
-            });
-            app.on_resize();
+            app.gctx_queue_mutex.lockUncancelable(app.io);
+            defer app.gctx_queue_mutex.unlock(app.io);
+            app.pending_resize = .{ .time = std.Io.Timestamp.now(app.io, .awake), .width = @intCast(width), .height = @intCast(height) };
         }
     }
 }
@@ -379,6 +371,8 @@ wayland: bool,
 gctx: *zgpu.GraphicsContext = undefined,
 gctx_queue_mutex: std.Io.Mutex = .init, // GPU Memory access isn't thread safe. Use this to copy to textures from another thread for example.
 scale_factor: f32 = 1.0,
+/// Track and debounce window resize events
+pending_resize: ?struct { time: std.Io.Timestamp, width: u32, height: u32 } = null,
 
 dc: *Dreamcast = undefined,
 renderer: *Renderer = undefined,
@@ -1103,6 +1097,29 @@ pub fn update(self: *@This(), delta_time: f32) void {
         self._stop_request = false;
         if (self._on_stop_request) |on_stop_request| on_stop_request(self);
     }
+}
+
+pub fn check_resize(self: *@This()) !enum { Normal, Resizing } {
+    if (self.pending_resize == null) return .Normal; // Fast check without locking the mutex.
+
+    try self.gctx_queue_mutex.lock(self.io);
+    defer self.gctx_queue_mutex.unlock(self.io);
+
+    const resize = self.pending_resize.?; // NOTE: Intentionally acquiring the value after locking.
+    if (resize.time.toMilliseconds() + 30 < std.Io.Timestamp.now(self.io, .awake).toMilliseconds()) {
+        self.gctx.surface.configure(.{
+            .device = self.gctx.device,
+            .format = zgpu.GraphicsContext.surface_texture_format,
+            .usage = .{ .render_attachment = true },
+            .width = resize.width,
+            .height = resize.height,
+            .present_mode = self.gctx.present_mode,
+        });
+        self.on_resize();
+        self.pending_resize = null;
+        return .Normal;
+    }
+    return .Resizing;
 }
 
 fn update_rumble(self: *@This(), dt: f32) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -200,6 +200,14 @@ pub fn main(init: std.process.Init) !void {
         d.update(@floatCast(now - then));
         then = now;
 
+        if (try d.check_resize() == .Resizing) {
+            // Skip rendering while resizing. Keep presenting to update window size.
+            try d.gctx_queue_mutex.lock(d.io);
+            defer d.gctx_queue_mutex.unlock(d.io);
+            _ = d.gctx.present();
+            continue;
+        }
+
         // Framebuffer has been written to by the CPU.
         // Update the host texture and blit it to our render target.
         // FIXME: Hackishly forced on for .bin files

--- a/src/ui/shortcuts.zig
+++ b/src/ui/shortcuts.zig
@@ -146,31 +146,29 @@ pub fn deinit(self: *@This(), allocator: std.mem.Allocator, io: std.Io) void {
     self.shortcuts.deinit();
 }
 
+fn app_ptr(self: *@This()) *Deecy {
+    return @alignCast(@fieldParentPtr("shortcuts", self));
+}
+
 pub fn on_press(self: *@This(), key: Key) void {
-    if (self.shortcuts.getPtr(key)) |shortcut| {
-        const deecy: *Deecy = @fieldParentPtr("shortcuts", self);
-        shortcut.call(deecy);
-    }
+    if (self.shortcuts.getPtr(key)) |shortcut|
+        shortcut.call(self.app_ptr());
 }
 
 /// Bypasses internal repeat timer. Intended to be used with the OS repeat logic.
 /// Do not mix on_repeat and on_hold with the same type of input device.
 pub fn on_repeat(self: *@This(), key: Key) void {
     if (self.shortcuts.getPtr(key)) |shortcut| {
-        if (shortcut.allow_repeat) {
-            const deecy: *Deecy = @fieldParentPtr("shortcuts", self);
-            shortcut.call(deecy);
-        }
+        if (shortcut.allow_repeat)
+            shortcut.call(self.app_ptr());
     }
 }
 
 /// Intended to be used with input without OS repeat logic (e.g. controller).
 /// Do not mix on_repeat and on_hold with the same type of input device.
 pub fn on_hold(self: *@This(), key: Key) void {
-    if (self.shortcuts.getPtr(key)) |shortcut| {
-        const deecy: *Deecy = @fieldParentPtr("shortcuts", self);
-        shortcut.on_hold(deecy);
-    }
+    if (self.shortcuts.getPtr(key)) |shortcut|
+        shortcut.on_hold(self.app_ptr());
 }
 
 pub fn put(self: *@This(), key: Key, action: Action.Name) !void {


### PR DESCRIPTION
Debounce window resizing events.
Necessary on Wayland: resizing events are queuing up and the application becomes completely unresponsive.
Needs testing in other environments.