### PR TITLE
Check JIT executable memory

### DIFF
--- a/src/dreamcast/aica_dsp.zig
+++ b/src/dreamcast/aica_dsp.zig
@@ -102,7 +102,7 @@ pub fn init(ring_buffer: *const AICAModule.RingBufferAddress, registers: []u32, 
 }
 
 pub fn deinit(self: *@This()) void {
-    if (self._jit_buffer) |buffer| host_memory.deallocate_executable(self._allocator, buffer);
+    if (self._jit_buffer) |buffer| host_memory.deallocate_executable(buffer);
 }
 
 pub inline fn read_register(self: *const @This(), comptime T: type, local_addr: u32) T {
@@ -350,7 +350,7 @@ pub fn compile(self: *@This()) !void {
     std.debug.assert(!FullRegisterEmulation); // TODO: Not supported yet.
 
     if (self._jit_buffer == null)
-        self._jit_buffer = try host_memory.allocate_executable(self._allocator, 0x8000);
+        self._jit_buffer = try host_memory.allocate_executable(0x8000);
 
     var b = try IRBlock.init(self._allocator);
     defer b.deinit();

--- a/src/dreamcast/host/host_memory.zig
+++ b/src/dreamcast/host/host_memory.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-pub fn allocate_executable(_: std.mem.Allocator, size: usize) ![]align(std.heap.page_size_min) u8 {
+pub fn allocate_executable(size: usize) ![]align(std.heap.page_size_min) u8 {
     switch (builtin.os.tag) {
         .windows => {
             var local_size: std.os.windows.SIZE_T = size;
@@ -31,7 +31,7 @@ pub fn allocate_executable(_: std.mem.Allocator, size: usize) ![]align(std.heap.
     }
 }
 
-pub fn deallocate_executable(_: std.mem.Allocator, memory: []align(std.heap.page_size_min) u8) void {
+pub fn deallocate_executable(memory: []align(std.heap.page_size_min) u8) void {
     switch (builtin.os.tag) {
         .windows => virtual_dealloc(memory),
         .linux => std.posix.munmap(memory),

--- a/src/dreamcast/host/host_memory.zig
+++ b/src/dreamcast/host/host_memory.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-pub fn allocate_executable(allocator: std.mem.Allocator, size: usize) ![]align(std.heap.page_size_min) u8 {
+pub fn allocate_executable(_: std.mem.Allocator, size: usize) ![]align(std.heap.page_size_min) u8 {
     switch (builtin.os.tag) {
         .windows => {
             var local_size: std.os.windows.SIZE_T = size;
@@ -17,22 +17,24 @@ pub fn allocate_executable(allocator: std.mem.Allocator, size: usize) ![]align(s
             return @as([*]align(std.heap.page_size_min) u8, @ptrCast(@alignCast(base_addr)))[0..size];
         },
         .linux => {
-            const r = try allocator.alignedAlloc(u8, .fromByteUnits(std.heap.page_size_min), size);
-            switch (std.posix.errno(std.posix.system.mprotect(r.ptr, size, .{ .READ = true, .WRITE = true, .EXEC = true }))) {
-                .SUCCESS => {},
-                .NOMEM => return error.OutOfMemory,
-                else => |err| return std.posix.unexpectedErrno(err),
-            }
-            return r;
+            const aligned_size = std.mem.alignForward(usize, size, std.heap.page_size_min);
+            return try std.posix.mmap(
+                null,
+                aligned_size,
+                .{ .READ = true, .WRITE = true, .EXEC = true },
+                .{ .TYPE = .PRIVATE, .ANONYMOUS = true },
+                -1,
+                0,
+            );
         },
         else => @compileError("Unsupported OS."),
     }
 }
 
-pub fn deallocate_executable(allocator: std.mem.Allocator, memory: []align(std.heap.page_size_min) u8) void {
+pub fn deallocate_executable(_: std.mem.Allocator, memory: []align(std.heap.page_size_min) u8) void {
     switch (builtin.os.tag) {
         .windows => virtual_dealloc(memory),
-        .linux => allocator.free(memory),
+        .linux => std.posix.munmap(memory),
         else => @compileError("Unsupported OS."),
     }
 }

--- a/src/dreamcast/jit/arm_jit.zig
+++ b/src/dreamcast/jit/arm_jit.zig
@@ -52,7 +52,7 @@ const BlockCache = struct {
 
     pub fn init(allocator: std.mem.Allocator, addr_mask: u32) !@This() {
         var r: @This() = .{
-            .buffer = try host_memory.allocate_executable(allocator, BlockBufferSize),
+            .buffer = try host_memory.allocate_executable(BlockBufferSize),
             .addr_mask = addr_mask,
             ._allocator = allocator,
         };
@@ -61,7 +61,7 @@ const BlockCache = struct {
     }
 
     pub fn deinit(self: *@This()) void {
-        host_memory.deallocate_executable(self._allocator, self.buffer);
+        host_memory.deallocate_executable(self.buffer);
         self.deallocate_blocks();
     }
 

--- a/src/dreamcast/jit/sh4_jit.zig
+++ b/src/dreamcast/jit/sh4_jit.zig
@@ -71,7 +71,7 @@ const BlockCache = struct {
 
     pub fn init(allocator: std.mem.Allocator) !@This() {
         var r: @This() = .{
-            .buffer = try host_memory.allocate_executable(allocator, BlockBufferSize),
+            .buffer = try host_memory.allocate_executable(BlockBufferSize),
             ._allocator = allocator,
         };
         try r.allocate_blocks();
@@ -79,7 +79,7 @@ const BlockCache = struct {
     }
 
     pub fn deinit(self: *@This()) void {
-        host_memory.deallocate_executable(self._allocator, self.buffer);
+        host_memory.deallocate_executable(self.buffer);
         self.deallocate_blocks();
     }
 


### PR DESCRIPTION
(Quick test)

Could also be a good occasion to explorer properly handling page protection (switching writing permission only when needed, i.e. when patching or compiling new blocks)