### PR TITLE
SCIF

### DIFF
--- a/src/dreamcast/sh4.zig
+++ b/src/dreamcast/sh4.zig
@@ -12,7 +12,7 @@ pub const sh4_log = std.log.scoped(.sh4);
 pub const mmu_log = std.log.scoped(.mmu);
 
 const DreamcastModule = @import("dreamcast.zig");
-const Context = DreamcastModule.Context;
+pub const Context = DreamcastModule.Context;
 const Dreamcast = DreamcastModule.Dreamcast;
 const HardwareRegisters = DreamcastModule.HardwareRegisters;
 const HardwareRegister = HardwareRegisters.HardwareRegister;
@@ -22,6 +22,7 @@ pub const P4 = @import("./sh4_p4.zig");
 pub const P4Register = P4.P4Register;
 const Interrupts = @import("sh4_interrupts.zig");
 const Interrupt = Interrupts.Interrupt;
+const SCIF = @import("sh4_scif.zig");
 
 pub const Exception = @import("sh4_exceptions.zig").Exception;
 
@@ -376,6 +377,15 @@ pub const SH4 = struct {
             self.p4_register(u16, timer.control).* = 0x0000;
         }
 
+        self.p4_register(u8, .SCSMR1).* = 0x00;
+        self.p4_register(u8, .SCBRR1).* = 0xFF;
+        self.p4_register(u8, .SCSCR1).* = 0x00;
+        self.p4_register(u8, .SCTDR1).* = 0xFF;
+        self.p4_register(u8, .SCSSR1).* = 0x84;
+        self.p4_register(u8, .SCRDR1).* = 0x00;
+        self.p4_register(u8, .SCSPTR1).* = 0x00;
+
+        self.p4_register(u16, .SCSMR2).* = 0x0000;
         self.p4_register(u8, .SCBRR2).* = 0xFF;
         self.p4_register(u16, .SCSCR2).* = 0x0000;
         self.p4_register(u16, .SCFSR2).* = 0x0060;
@@ -1189,12 +1199,6 @@ pub const SH4 = struct {
         });
     }
 
-    inline fn check_type(comptime Valid: []const type, comptime T: type, comptime fmt: []const u8, param: anytype) void {
-        inline for (Valid) |V| if (T == V) return;
-        std.debug.print(fmt, param);
-        unreachable;
-    }
-
     pub fn read_p4(self: *const @This(), comptime T: type, virtual_addr: u32) T {
         std.debug.assert(virtual_addr & 0xE0000000 == 0xE0000000);
 
@@ -1592,50 +1596,8 @@ pub const SH4 = struct {
                             }
                             return;
                         },
-                        // Serial Interface
-                        @intFromEnum(P4Register.SCFTDR2) => {
-                            check_type(&[_]type{u8}, T, "Invalid P4 Write({}) to SCFTDR2\n", .{T});
-
-                            var stdout_buffer: [128]u8 = undefined;
-                            var stdout_writer = std.Io.File.stdout().writer(Context.io, &stdout_buffer);
-                            const stdout = &stdout_writer.interface;
-
-                            stdout.print("\u{001b}[44m\u{001b}[97m{c}\u{001b}[0m", .{value}) catch |err| {
-                                sh4_log.err(termcolor.red("Error writing serial output: {}\n"), .{err});
-                            };
-                            stdout.flush() catch |err| {
-                                sh4_log.err(termcolor.red("Error flushing stdout: {}\n"), .{err});
-                            };
-
-                            // Immediately mark transfer as complete.
-                            const status_register = self.p4_register(P4.SCFSR2, .SCFSR2);
-                            status_register.tdfe = true;
-
-                            const control_register = self.p4_register(P4.SCSCR2, .SCSCR2);
-                            const fifo_control = self.p4_register(P4.SCFCR2, .SCFCR2);
-                            if (control_register.tie) {
-                                sh4_log.warn("Unimplemented SCIF_TXI interrupt enabled at {d} bytes.", .{fifo_control.ttrg.bytes()});
-                                // self.request_interrupt(Interrupt.SCIF_TXI);
-                            }
-                            return;
-                        },
-                        @intFromEnum(P4Register.SCFSR2) => {
-                            check_type(&[_]type{u16}, T, "Invalid P4 Write({}) to SCFSR2\n", .{T});
-                            const val: P4.SCFSR2 = @bitCast(value);
-                            sh4_log.debug("Write to SCFSR2: {any}", .{val});
-                            // Writable bits can only be cleared.
-                            // TODO: "Also note that in order to clear these flags they must be read as 1 beforehand."
-                            // self.p4_register(u16, .SCFSR2).* &= (value | 0b11111111_00001100);
-                            return;
-                        },
-                        @intFromEnum(P4Register.SCFCR2) => {
-                            // FIFO Control Register
-                            check_type(&[_]type{u16}, T, "Invalid P4 Write({}) to SCFCR2\n", .{T});
-                            const val: P4.SCFCR2 = @bitCast(value);
-                            sh4_log.debug("Write to SCFCR2: {any}", .{val});
-                            if (val.rfrst) sh4_log.debug("  Resetting Receive FIFO", .{});
-                            if (val.tfrst) sh4_log.debug("  Resetting Transmit FIFO", .{});
-                            // self.p4_register(P4.SCFCR2, .SCFSR2).* = val;
+                        0xFFE80000...0xFFE80026 => {
+                            SCIF.write(self, T, virtual_addr, value);
                             return;
                         },
                         0xFFEB0000 => {
@@ -1975,3 +1937,9 @@ pub const SH4 = struct {
         self.check_mmu_state();
     }
 };
+
+pub inline fn check_type(comptime Valid: []const type, comptime T: type, comptime fmt: []const u8, param: anytype) void {
+    inline for (Valid) |V| if (T == V) return;
+    std.debug.print(fmt, param);
+    unreachable;
+}

--- a/src/dreamcast/sh4.zig
+++ b/src/dreamcast/sh4.zig
@@ -20,8 +20,8 @@ const HardwareRegister = HardwareRegisters.HardwareRegister;
 pub const mmu = @import("./sh4_mmu.zig");
 pub const P4 = @import("./sh4_p4.zig");
 pub const P4Register = P4.P4Register;
-const Interrupts = @import("sh4_interrupts.zig");
-const Interrupt = Interrupts.Interrupt;
+pub const Interrupts = @import("sh4_interrupts.zig");
+pub const Interrupt = Interrupts.Interrupt;
 const SCIF = @import("sh4_scif.zig");
 
 pub const Exception = @import("sh4_exceptions.zig").Exception;
@@ -777,8 +777,8 @@ pub const SH4 = struct {
         self._interrupt_levels[@intFromEnum(Interrupt.SCI1_TEI)] = IPRB.sci1;
         self._interrupt_levels[@intFromEnum(Interrupt.SCIF_ERI)] = IPRC.scif;
         self._interrupt_levels[@intFromEnum(Interrupt.SCIF_RXI)] = IPRC.scif;
+        self._interrupt_levels[@intFromEnum(Interrupt.SCIF_BRI)] = IPRC.scif;
         self._interrupt_levels[@intFromEnum(Interrupt.SCIF_TXI)] = IPRC.scif;
-        self._interrupt_levels[@intFromEnum(Interrupt.SCIF_TEI)] = IPRC.scif;
         self._interrupt_levels[@intFromEnum(Interrupt.ITI)] = IPRB.wdt;
         self._interrupt_levels[@intFromEnum(Interrupt.RCMI)] = IPRB.ref;
         self._interrupt_levels[@intFromEnum(Interrupt.ROVI)] = IPRB.ref;
@@ -1291,6 +1291,9 @@ pub const SH4 = struct {
             0xFC000000...0xFFFFFFFF => {
                 // Control register area
                 if (virtual_addr >= 0xFF000000) {
+                    if (virtual_addr >= 0xFFE80000 and virtual_addr <= 0xFFE80026)
+                        return SCIF.read(self, T, virtual_addr);
+
                     const p4_reg: P4Register = @enumFromInt(virtual_addr);
                     switch (p4_reg) {
                         .RFCR => {

--- a/src/dreamcast/sh4.zig
+++ b/src/dreamcast/sh4.zig
@@ -22,7 +22,7 @@ pub const P4 = @import("./sh4_p4.zig");
 pub const P4Register = P4.P4Register;
 pub const Interrupts = @import("sh4_interrupts.zig");
 pub const Interrupt = Interrupts.Interrupt;
-const SCIF = @import("sh4_scif.zig");
+pub const SCIF = @import("sh4_scif.zig");
 
 pub const Exception = @import("sh4_exceptions.zig").Exception;
 

--- a/src/dreamcast/sh4_interrupts.zig
+++ b/src/dreamcast/sh4_interrupts.zig
@@ -41,8 +41,8 @@ pub const Interrupt = enum {
     SCI1_TEI,
     SCIF_ERI,
     SCIF_RXI,
+    SCIF_BRI,
     SCIF_TXI,
-    SCIF_TEI,
     ITI,
     RCMI,
     ROVI,
@@ -85,8 +85,8 @@ pub const InterruptINTEVTCodes: [41]u32 = .{
     0x540, // SCI1_TEI
     0x700, // SCIF_ERI
     0x720, // SCIF_RXI
-    0x740, // SCIF_TXI
-    0x760, // SCIF_TEI
+    0x740, // SCIF_BRI
+    0x760, // SCIF_TXI
     0x560, // ITI
     0x580, // RCMI
     0x5A0, // ROVI
@@ -130,8 +130,8 @@ pub const DefaultInterruptPriorities: [41]Interrupt = .{
     .SCI1_TEI,
     .SCIF_ERI,
     .SCIF_RXI,
+    .SCIF_BRI,
     .SCIF_TXI,
-    .SCIF_TEI,
     .ITI,
     .RCMI,
     .ROVI,
@@ -175,8 +175,8 @@ pub const DefaultInterruptLevels: [41]u32 = .{
     0, // SCI1_TEI
     0, // SCIF_ERI
     0, // SCIF_RXI
+    0, // SCIF_BRI
     0, // SCIF_TXI
-    0, // SCIF_TEI
     0, // ITI
     0, // RCMI
     0, // ROVI

--- a/src/dreamcast/sh4_p4.zig
+++ b/src/dreamcast/sh4_p4.zig
@@ -486,6 +486,13 @@ pub const SCFSR2 = packed struct(u16) {
     per_number: u4 = 0,
 };
 
+/// Line Status Register
+pub const SCLSR2 = packed struct(u16) {
+    /// Overrun Error (ORER): Indicates that an overrun error occurred during reception, causing abnormal termination.
+    orer: bool = false,
+    _: u15 = 0,
+};
+
 const PerformanceMeasurementItems = enum(u6) {
     @"(nop)" = 0x00,
     @"Operand access (read/with cache)" = 0x01, // Count

--- a/src/dreamcast/sh4_p4.zig
+++ b/src/dreamcast/sh4_p4.zig
@@ -107,13 +107,21 @@ pub const P4Register = enum(u32) {
     TCPR2 = 0xFFD8002C,
 
     // SCI
+    /// Serial mode register
     SCSMR1 = 0xFFE00000,
+    /// Bit rate register
     SCBRR1 = 0xFFE00004,
+    /// Serial control register
     SCSCR1 = 0xFFE00008,
+    /// Transmit data register
     SCTDR1 = 0xFFE0000C,
+    /// Serial status register
     SCSSR1 = 0xFFE00010,
+    /// Receive data register
     SCRDR1 = 0xFFE00014,
+    /// Smart card mode register
     SCSCMR1 = 0xFFE00018,
+    /// Serial port register
     SCSPTR1 = 0xFFE0001C,
 
     // SCIF

--- a/src/dreamcast/sh4_scif.zig
+++ b/src/dreamcast/sh4_scif.zig
@@ -1,39 +1,59 @@
 //! Serial Communication Interface with FIFO (SCIF)
 
 var stdin_intialized = false;
-var stdin_buffer: [128]u8 = undefined;
+var stdin_buffer: [16]u8 = undefined;
 var stdin_reader: std.Io.File.Reader = undefined;
+
+var read_scfsr2: P4.SCFSR2 = .{}; // FIXME: Not serialized.
+
+fn check_rx(self: *const SH4) void {
+    if (!stdin_intialized) {
+        stdin_reader = std.Io.File.stdin().readerStreaming(SH4Module.Context.io, &stdin_buffer);
+        stdin_intialized = true;
+    }
+
+    // Check if serial receive is enabled.
+    const serial_control_register = self.p4_register(P4.SCSCR2, .SCSCR2).*;
+    if (!serial_control_register.re) return;
+
+    var fds = [_]std.posix.pollfd{.{
+        .fd = std.Io.File.stdin().handle,
+        .events = std.posix.POLL.IN,
+        .revents = 0,
+    }};
+
+    const ready = std.posix.poll(&fds, 0) catch return;
+    if (ready > 0 or stdin_reader.interface.bufferedLen() > 0) {
+        const byte = stdin_reader.interface.peekByte() catch unreachable;
+        log.debug("Read from stdin: {}", .{byte});
+        self.p4_register(u8, .SCFRDR2).* = byte;
+        const fifo_control_register = self.p4_register(P4.SCFCR2, .SCFCR2).*;
+
+        var status_register = self.p4_register(P4.SCFSR2, .SCFSR2);
+        if (stdin_reader.interface.bufferedLen() >= fifo_control_register.rtrg.bytes())
+            status_register.rdf = true;
+        if (stdin_reader.interface.bufferedLen() < fifo_control_register.rtrg.bytes())
+            status_register.dr = true;
+
+        update_interrupts(@constCast(self));
+    }
+}
 
 pub fn read(self: *const SH4, comptime T: type, virtual_addr: u32) T {
     const p4_reg: SH4Module.P4Register = @enumFromInt(virtual_addr);
     switch (p4_reg) {
         .SCFSR2 => {
             SH4Module.check_type(&[_]type{u16}, T, "Invalid P4 Write({}) to SCFSR2\n", .{T});
-            var val = self.p4_register(P4.SCFSR2, .SCFSR2).*;
-
-            if (!stdin_intialized) {
-                stdin_reader = std.Io.File.stdin().readerStreaming(SH4Module.Context.io, &stdin_buffer);
-                stdin_intialized = true;
-            }
-            var fds = [_]std.posix.pollfd{.{
-                .fd = std.Io.File.stdin().handle,
-                .events = std.posix.POLL.IN,
-                .revents = 0,
-            }};
-
-            const ready = std.posix.poll(&fds, 0) catch return @bitCast(val);
-            if (ready > 0) {
-                const byte = stdin_reader.interface.takeByte() catch unreachable;
-                log.debug("Read from stdin: {}", .{byte});
-                self.p4_register(u8, .SCFRDR2).* = byte;
-                const control_register = self.p4_register(P4.SCFCR2, .SCFCR2).*;
-                val.rdf = stdin_reader.interface.bufferedLen() >= control_register.rtrg.bytes();
-                val.dr = stdin_reader.interface.bufferedLen() < control_register.rtrg.bytes();
-
-                self.p4_register(P4.SCFSR2, .SCFSR2).* = val;
-                update_interrupts(@constCast(self));
-            }
-            return @bitCast(val);
+            check_rx(self);
+            const status = self.p4_register(P4.SCFSR2, .SCFSR2).*;
+            read_scfsr2 = status;
+            return @bitCast(status);
+        },
+        .SCFRDR2 => {
+            // FIXME: Currently blocking if stdin is empty (should poll).
+            const byte = stdin_reader.interface.takeByte() catch unreachable;
+            check_rx(self);
+            return byte;
         },
         else => {
             return self.p4_register_addr(T, virtual_addr).*;
@@ -80,10 +100,10 @@ pub fn write(self: *SH4, comptime T: type, virtual_addr: u32, value: T) void {
             log.debug("Write to SCFSR2: {any}", .{val});
             // Writable bits can only be cleared.
             // "Note: * Only 0 can be written, to clear the flag.""
-            // TODO: "Also note that in order to clear these flags they must be read as 1 beforehand."
+            // "Also note that in order to clear these flags they must be read as 1 beforehand."
             const scfsr2 = self.p4_register(P4.SCFSR2, .SCFSR2);
             inline for (.{ "dr", "rdf", "brk", "tdfe", "tend", "er" }) |flag| {
-                if (!@field(val, flag)) @field(scfsr2, flag) = false;
+                if (!@field(val, flag) and @field(read_scfsr2, flag)) @field(scfsr2, flag) = false;
             }
             // Always mark transmission as complete/FIFO not full.
             scfsr2.tdfe = true;

--- a/src/dreamcast/sh4_scif.zig
+++ b/src/dreamcast/sh4_scif.zig
@@ -116,10 +116,19 @@ pub fn write(self: *SH4, comptime T: type, virtual_addr: u32, value: T) void {
             SH4Module.check_type(&[_]type{u16}, T, "Invalid P4 Write({}) to SCFCR2\n", .{T});
             const val: P4.SCFCR2 = @bitCast(value);
             log.debug("Write to SCFCR2: {any}", .{val});
-            if (val.rfrst) log.debug("  Resetting Receive FIFO", .{});
+            if (val.rfrst) {
+                log.debug("  Resetting Receive FIFO", .{});
+                check_rx(self);
+                stdin_reader.interface.tossBuffered();
+                check_rx(self);
+            }
             if (val.tfrst) log.debug("  Resetting Transmit FIFO", .{});
             self.p4_register(P4.SCFCR2, .SCFCR2).* = val;
             return;
+        },
+        .SCLSR2, .SCSCR2 => {
+            self.p4_register_addr(T, virtual_addr).* = value;
+            update_interrupts(self);
         },
         else => {
             self.p4_register_addr(T, virtual_addr).* = value;

--- a/src/dreamcast/sh4_scif.zig
+++ b/src/dreamcast/sh4_scif.zig
@@ -1,0 +1,62 @@
+//! Serial Communication Interface with FIFO (SCIF)
+
+pub fn write(self: *SH4, comptime T: type, virtual_addr: u32, value: T) void {
+    const p4_reg: SH4Module.P4Register = @enumFromInt(virtual_addr);
+    log.debug("Write to {t}: {any}", .{ p4_reg, value });
+    switch (p4_reg) {
+        .SCFTDR2 => {
+            SH4Module.check_type(&[_]type{u8}, T, "Invalid P4 Write({}) to SCFTDR2\n", .{T});
+
+            var stdout_buffer: [128]u8 = undefined;
+            var stdout_writer = std.Io.File.stdout().writer(SH4Module.Context.io, &stdout_buffer);
+            const stdout = &stdout_writer.interface;
+
+            stdout.print("\u{001b}[44m\u{001b}[97m{c}\u{001b}[0m", .{value}) catch |err| {
+                log.err("Error writing serial output: {}\n", .{err});
+            };
+            stdout.flush() catch |err| {
+                log.err("Error flushing stdout: {}\n", .{err});
+            };
+
+            // Immediately mark transfer as complete.
+            const status_register = self.p4_register(P4.SCFSR2, .SCFSR2);
+            status_register.tdfe = true;
+
+            const control_register = self.p4_register(P4.SCSCR2, .SCSCR2);
+            const fifo_control = self.p4_register(P4.SCFCR2, .SCFCR2);
+            if (control_register.tie) {
+                log.warn("Unimplemented SCIF_TXI interrupt enabled at {d} bytes.", .{fifo_control.ttrg.bytes()});
+                // self.request_interrupt(Interrupt.SCIF_TXI);
+            }
+            return;
+        },
+        .SCFSR2 => {
+            SH4Module.check_type(&[_]type{u16}, T, "Invalid P4 Write({}) to SCFSR2\n", .{T});
+            const val: P4.SCFSR2 = @bitCast(value);
+            log.debug("Write to SCFSR2: {any}", .{val});
+            // Writable bits can only be cleared.
+            // TODO: "Also note that in order to clear these flags they must be read as 1 beforehand."
+            // self.p4_register(u16, .SCFSR2).* &= (value | 0b11111111_00001100);
+            return;
+        },
+        .SCFCR2 => {
+            // FIFO Control Register
+            SH4Module.check_type(&[_]type{u16}, T, "Invalid P4 Write({}) to SCFCR2\n", .{T});
+            const val: P4.SCFCR2 = @bitCast(value);
+            log.debug("Write to SCFCR2: {any}", .{val});
+            if (val.rfrst) log.debug("  Resetting Receive FIFO", .{});
+            if (val.tfrst) log.debug("  Resetting Transmit FIFO", .{});
+            // self.p4_register(P4.SCFCR2, .SCFSR2).* = val;
+            return;
+        },
+        else => {
+            self.p4_register_addr(T, virtual_addr).* = value;
+        },
+    }
+}
+
+const std = @import("std");
+const log = std.log.scoped(.sh4_scif);
+const SH4Module = @import("sh4.zig");
+const SH4 = SH4Module.SH4;
+const P4 = SH4Module.P4;

--- a/src/dreamcast/sh4_scif.zig
+++ b/src/dreamcast/sh4_scif.zig
@@ -4,10 +4,13 @@ var stdin_intialized = false;
 var stdin_buffer: [16]u8 = undefined;
 var stdin_reader: std.Io.File.Reader = undefined;
 
-var read_scfsr2: P4.SCFSR2 = .{}; // FIXME: Not serialized.
+/// Used to prevent clearing bits from SCFSR2 before they are read.
+/// FIXME: Not serialized.
+var read_scfsr2: P4.SCFSR2 = .{};
 
 fn check_rx(self: *const SH4) void {
     if (!stdin_intialized) {
+        // FIXME: Redirect to custom FD instead?
         stdin_reader = std.Io.File.stdin().readerStreaming(SH4Module.Context.io, &stdin_buffer);
         stdin_intialized = true;
     }
@@ -16,19 +19,23 @@ fn check_rx(self: *const SH4) void {
     const serial_control_register = self.p4_register(P4.SCSCR2, .SCSCR2).*;
     if (!serial_control_register.re) return;
 
+    // TODO: Windows support?
+
+    // Check if there is data to read.
+    // FIXME: Is it the best way to do this?
     var fds = [_]std.posix.pollfd{.{
         .fd = std.Io.File.stdin().handle,
         .events = std.posix.POLL.IN,
         .revents = 0,
     }};
-
     const ready = std.posix.poll(&fds, 0) catch return;
     if (ready > 0 or stdin_reader.interface.bufferedLen() > 0) {
+        // FIXME: This is only here to populate the buffer.
         const byte = stdin_reader.interface.peekByte() catch unreachable;
-        log.debug("Read from stdin: {}", .{byte});
         self.p4_register(u8, .SCFRDR2).* = byte;
-        const fifo_control_register = self.p4_register(P4.SCFCR2, .SCFCR2).*;
+        log.debug("Read from stdin: {}", .{byte});
 
+        const fifo_control_register = self.p4_register(P4.SCFCR2, .SCFCR2).*;
         var status_register = self.p4_register(P4.SCFSR2, .SCFSR2);
         if (stdin_reader.interface.bufferedLen() >= fifo_control_register.rtrg.bytes())
             status_register.rdf = true;
@@ -50,7 +57,7 @@ pub fn read(self: *const SH4, comptime T: type, virtual_addr: u32) T {
             return @bitCast(status);
         },
         .SCFRDR2 => {
-            // FIXME: Currently blocking if stdin is empty (should poll).
+            // FIXME: Currently blocking if stdin is empty (should poll for safety).
             const byte = stdin_reader.interface.takeByte() catch unreachable;
             check_rx(self);
             return byte;
@@ -73,7 +80,9 @@ pub fn write(self: *SH4, comptime T: type, virtual_addr: u32, value: T) void {
             const stdout = &stdout_writer.interface;
 
             log.debug("Serial FIFO out: {c}", .{value});
+            // TODO: Make this configurable.
             if (false) {
+                // Colored output to stdout.
                 stdout.print("\u{001b}[44m\u{001b}[97m{c}\u{001b}[0m", .{value}) catch |err| {
                     log.err("Error writing serial output: {}\n", .{err});
                 };
@@ -99,15 +108,16 @@ pub fn write(self: *SH4, comptime T: type, virtual_addr: u32, value: T) void {
             const val: P4.SCFSR2 = @bitCast(value);
             log.debug("Write to SCFSR2: {any}", .{val});
             // Writable bits can only be cleared.
-            // "Note: * Only 0 can be written, to clear the flag.""
-            // "Also note that in order to clear these flags they must be read as 1 beforehand."
-            const scfsr2 = self.p4_register(P4.SCFSR2, .SCFSR2);
+            //   "Note: * Only 0 can be written, to clear the flag.""
+            //   "Also note that in order to clear these flags they must be read as 1 beforehand."
+            const status_register = self.p4_register(P4.SCFSR2, .SCFSR2);
             inline for (.{ "dr", "rdf", "brk", "tdfe", "tend", "er" }) |flag| {
-                if (!@field(val, flag) and @field(read_scfsr2, flag)) @field(scfsr2, flag) = false;
+                if (!@field(val, flag) and @field(read_scfsr2, flag))
+                    @field(status_register, flag) = false;
             }
             // Always mark transmission as complete/FIFO not full.
-            scfsr2.tdfe = true;
-            scfsr2.tend = true;
+            status_register.tdfe = true;
+            status_register.tend = true;
             update_interrupts(self);
             return;
         },

--- a/src/dreamcast/sh4_scif.zig
+++ b/src/dreamcast/sh4_scif.zig
@@ -1,48 +1,73 @@
 //! Serial Communication Interface with FIFO (SCIF)
 
-var stdin_intialized = false;
-var stdin_buffer: [16]u8 = undefined;
-var stdin_reader: std.Io.File.Reader = undefined;
+var pty: ?std.Io.File = null;
+var rx_buffer: [16]u8 = undefined;
+var rx_reader: std.Io.File.Reader = undefined;
+var tx_buffer: [16]u8 = undefined;
+var tx_writer: std.Io.File.Writer = undefined;
 
 /// Used to prevent clearing bits from SCFSR2 before they are read.
 /// FIXME: Not serialized.
 var read_scfsr2: P4.SCFSR2 = .{};
 
-fn check_rx(self: *const SH4) void {
-    if (!stdin_intialized) {
-        // FIXME: Redirect to custom FD instead?
-        stdin_reader = std.Io.File.stdin().readerStreaming(SH4Module.Context.io, &stdin_buffer);
-        stdin_intialized = true;
+const DefaultSymlink = "/tmp/deecy/scif";
+
+/// Links the SCIF to /dev/ptmx
+pub fn init(io: std.Io) !void {
+    if (pty) |_| return;
+
+    switch (builtin.os.tag) {
+        .linux => {
+            pty = std.Io.Dir.cwd().openFile(io, "/dev/ptmx", .{ .mode = .read_write }) catch |err|
+                return log.err("Failed to open /dev/ptmx: {t}\n", .{err});
+
+            errdefer {
+                pty.?.close(SH4Module.Context.io);
+                pty = null;
+            }
+
+            if (c.grantpt(pty.?.handle) < 0) return error.PtyCreationFailed;
+            if (c.unlockpt(pty.?.handle) < 0) return error.PtyCreationFailed;
+
+            const pty_name = c.ptsname(pty.?.handle);
+            log.info(termcolor.green("[+]") ++ " Opened PTY: {s}", .{pty_name});
+
+            // NOTE: Placing the symlink at the root of /tmp causes issues when trying to access it with elevated privileges
+            //       (as required by `dc-tool-ser` with `-c`). This is a workaround for this issue.
+            switch (std.os.linux.errno(std.os.linux.mkdir("/tmp/deecy", 0o777))) {
+                .SUCCESS, .EXIST => {},
+                else => |err| log.err("Failed to create /tmp/deecy: {t}.", .{err}),
+            }
+            switch (std.os.linux.errno(std.os.linux.unlink(DefaultSymlink))) {
+                .SUCCESS, .NOENT => {},
+                else => |err| log.err("Failed to unlink symlink '{s}': {t}.", .{ DefaultSymlink, err }),
+            }
+            switch (std.os.linux.errno(std.os.linux.symlink(pty_name, DefaultSymlink))) {
+                .SUCCESS => log.info(termcolor.green("[+]") ++ " Serial interface available at '{s}'.", .{DefaultSymlink}),
+                else => |err| log.err("Failed to create symlink '{s}': {t}.", .{ DefaultSymlink, err }),
+            }
+
+            rx_reader = pty.?.readerStreaming(io, &rx_buffer);
+            tx_writer = pty.?.writerStreaming(io, &tx_buffer);
+        },
+        // TODO: Windows support?
+        else => log.err("SCIF redirection is not supported on {t}.", .{builtin.os.tag}),
     }
+}
 
-    // Check if serial receive is enabled.
-    const serial_control_register = self.p4_register(P4.SCSCR2, .SCSCR2).*;
-    if (!serial_control_register.re) return;
-
-    // TODO: Windows support?
-
-    // Check if there is data to read.
-    // FIXME: Is it the best way to do this?
-    var fds = [_]std.posix.pollfd{.{
-        .fd = std.Io.File.stdin().handle,
-        .events = std.posix.POLL.IN,
-        .revents = 0,
-    }};
-    const ready = std.posix.poll(&fds, 0) catch return;
-    if (ready > 0 or stdin_reader.interface.bufferedLen() > 0) {
-        // FIXME: This is only here to populate the buffer.
-        const byte = stdin_reader.interface.peekByte() catch unreachable;
-        self.p4_register(u8, .SCFRDR2).* = byte;
-        log.debug("Read from stdin: {}", .{byte});
-
-        const fifo_control_register = self.p4_register(P4.SCFCR2, .SCFCR2).*;
-        var status_register = self.p4_register(P4.SCFSR2, .SCFSR2);
-        if (stdin_reader.interface.bufferedLen() >= fifo_control_register.rtrg.bytes())
-            status_register.rdf = true;
-        if (stdin_reader.interface.bufferedLen() < fifo_control_register.rtrg.bytes())
-            status_register.dr = true;
-
-        update_interrupts(@constCast(self));
+pub fn deinit(io: std.Io) void {
+    if (pty) |p| {
+        switch (builtin.os.tag) {
+            .linux => {
+                switch (std.os.linux.errno(std.os.linux.unlink(DefaultSymlink))) {
+                    .SUCCESS, .NOENT => {},
+                    else => |err| log.err("Failed to unlink symlink '{s}': {t}.", .{ DefaultSymlink, err }),
+                }
+                p.close(io);
+            },
+            else => {},
+        }
+        pty = null;
     }
 }
 
@@ -57,10 +82,15 @@ pub fn read(self: *const SH4, comptime T: type, virtual_addr: u32) T {
             return @bitCast(status);
         },
         .SCFRDR2 => {
-            // FIXME: Currently blocking if stdin is empty (should poll for safety).
-            const byte = stdin_reader.interface.takeByte() catch unreachable;
-            check_rx(self);
-            return byte;
+            if (pty) |_| {
+                defer check_rx(self);
+                const byte = rx_reader.interface.takeByte() catch |err| {
+                    log.err("Error reading from serial: {}\n", .{err});
+                    return 0;
+                };
+                return byte;
+            }
+            return 0;
         },
         else => {
             return self.p4_register_addr(T, virtual_addr).*;
@@ -75,25 +105,24 @@ pub fn write(self: *SH4, comptime T: type, virtual_addr: u32, value: T) void {
         .SCFTDR2 => {
             SH4Module.check_type(&[_]type{u8}, T, "Invalid P4 Write({}) to SCFTDR2\n", .{T});
 
-            var stdout_buffer: [128]u8 = undefined;
-            var stdout_writer = std.Io.File.stdout().writer(SH4Module.Context.io, &stdout_buffer);
-            const stdout = &stdout_writer.interface;
-
             log.debug("Serial FIFO out: {c}", .{value});
-            // TODO: Make this configurable.
-            if (false) {
-                // Colored output to stdout.
-                stdout.print("\u{001b}[44m\u{001b}[97m{c}\u{001b}[0m", .{value}) catch |err| {
-                    log.err("Error writing serial output: {}\n", .{err});
-                };
+
+            if (pty) |_| {
+                // Raw output to pseudo-terminal.
+                tx_writer.interface.writeByte(value) catch |err|
+                    log.err("Error writing serial output: {t}", .{err});
+                tx_writer.interface.flush() catch |err|
+                    log.err("Error flushing serial output: {t}", .{err});
             } else {
-                stdout.writeByte(value) catch |err| {
-                    log.err("Error writing serial output: {}\n", .{err});
-                };
+                // Colored output to stdout.
+                var stdout_buffer: [128]u8 = undefined;
+                var stdout_writer = std.Io.File.stdout().writer(SH4Module.Context.io, &stdout_buffer);
+                const stdout = &stdout_writer.interface;
+                stdout.print("\u{001b}[44m\u{001b}[97m{c}\u{001b}[0m", .{value}) catch |err|
+                    log.err("Error writing serial output: {t}", .{err});
+                stdout.flush() catch |err|
+                    log.err("Error flushing stdout: {t}", .{err});
             }
-            stdout.flush() catch |err| {
-                log.err("Error flushing stdout: {}\n", .{err});
-            };
 
             // Immediately mark transfer as complete/FIFO not full.
             const status_register = self.p4_register(P4.SCFSR2, .SCFSR2);
@@ -129,7 +158,7 @@ pub fn write(self: *SH4, comptime T: type, virtual_addr: u32, value: T) void {
             if (val.rfrst) {
                 log.debug("  Resetting Receive FIFO", .{});
                 check_rx(self);
-                stdin_reader.interface.tossBuffered();
+                rx_reader.interface.tossBuffered();
                 check_rx(self);
             }
             if (val.tfrst) log.debug("  Resetting Transmit FIFO", .{});
@@ -146,6 +175,47 @@ pub fn write(self: *SH4, comptime T: type, virtual_addr: u32, value: T) void {
     }
 }
 
+fn check_rx(self: *const SH4) void {
+    // Check if serial receive is enabled.
+    const serial_control_register = self.p4_register(P4.SCSCR2, .SCSCR2).*;
+    if (!serial_control_register.re) return;
+
+    if (pty) |p| {
+        switch (builtin.os.tag) {
+            .linux => {
+                // Check if there is data to read.
+                // FIXME: Is it the best way to do this?
+                var fds = [_]std.posix.pollfd{.{
+                    .fd = p.handle,
+                    .events = std.posix.POLL.IN,
+                    .revents = 0,
+                }};
+                const ready = std.posix.poll(&fds, 0) catch return;
+                if ((ready > 0 and fds[0].revents & std.posix.POLL.IN != 0) or rx_reader.interface.bufferedLen() > 0)
+                    on_rx(self);
+            },
+            else => {},
+        }
+    }
+}
+
+fn on_rx(self: *const SH4) void {
+    // FIXME: This is only here to populate the buffer.
+    const byte = rx_reader.interface.peekByte() catch |err|
+        return log.err("Error peeking byte: {}\n", .{err});
+    self.p4_register(u8, .SCFRDR2).* = byte;
+    log.debug("Read from serial: {}", .{byte});
+
+    const fifo_control_register = self.p4_register(P4.SCFCR2, .SCFCR2).*;
+    var status_register = self.p4_register(P4.SCFSR2, .SCFSR2);
+    if (rx_reader.interface.bufferedLen() >= fifo_control_register.rtrg.bytes())
+        status_register.rdf = true;
+    if (rx_reader.interface.bufferedLen() < fifo_control_register.rtrg.bytes())
+        status_register.dr = true;
+
+    update_interrupts(@constCast(self));
+}
+
 fn update_interrupts(self: *SH4) void {
     const status_register = self.p4_register(P4.SCFSR2, .SCFSR2);
     const line_status_register = self.p4_register(P4.SCLSR2, .SCLSR2);
@@ -157,8 +227,15 @@ fn update_interrupts(self: *SH4) void {
     self.set_interrupt(SH4Module.Interrupt.SCIF_ERI, status_register.er and (control_register.rie or control_register.reie));
 }
 
+const c = @cImport({
+    @cDefine("_XOPEN_SOURCE", "500");
+    @cInclude("stdlib.h");
+});
+
+const builtin = @import("builtin");
 const std = @import("std");
 const log = std.log.scoped(.sh4_scif);
+const termcolor = @import("termcolor");
 const SH4Module = @import("sh4.zig");
 const SH4 = SH4Module.SH4;
 const P4 = SH4Module.P4;

--- a/src/dreamcast/sh4_scif.zig
+++ b/src/dreamcast/sh4_scif.zig
@@ -1,5 +1,46 @@
 //! Serial Communication Interface with FIFO (SCIF)
 
+var stdin_intialized = false;
+var stdin_buffer: [128]u8 = undefined;
+var stdin_reader: std.Io.File.Reader = undefined;
+
+pub fn read(self: *const SH4, comptime T: type, virtual_addr: u32) T {
+    const p4_reg: SH4Module.P4Register = @enumFromInt(virtual_addr);
+    switch (p4_reg) {
+        .SCFSR2 => {
+            SH4Module.check_type(&[_]type{u16}, T, "Invalid P4 Write({}) to SCFSR2\n", .{T});
+            var val = self.p4_register(P4.SCFSR2, .SCFSR2).*;
+
+            if (!stdin_intialized) {
+                stdin_reader = std.Io.File.stdin().readerStreaming(SH4Module.Context.io, &stdin_buffer);
+                stdin_intialized = true;
+            }
+            var fds = [_]std.posix.pollfd{.{
+                .fd = std.Io.File.stdin().handle,
+                .events = std.posix.POLL.IN,
+                .revents = 0,
+            }};
+
+            const ready = std.posix.poll(&fds, 0) catch return @bitCast(val);
+            if (ready > 0) {
+                const byte = stdin_reader.interface.takeByte() catch unreachable;
+                log.debug("Read from stdin: {}", .{byte});
+                self.p4_register(u8, .SCFRDR2).* = byte;
+                const control_register = self.p4_register(P4.SCFCR2, .SCFCR2).*;
+                val.rdf = stdin_reader.interface.bufferedLen() >= control_register.rtrg.bytes();
+                val.dr = stdin_reader.interface.bufferedLen() < control_register.rtrg.bytes();
+
+                self.p4_register(P4.SCFSR2, .SCFSR2).* = val;
+                update_interrupts(@constCast(self));
+            }
+            return @bitCast(val);
+        },
+        else => {
+            return self.p4_register_addr(T, virtual_addr).*;
+        },
+    }
+}
+
 pub fn write(self: *SH4, comptime T: type, virtual_addr: u32, value: T) void {
     const p4_reg: SH4Module.P4Register = @enumFromInt(virtual_addr);
     log.debug("Write to {t}: {any}", .{ p4_reg, value });
@@ -11,23 +52,26 @@ pub fn write(self: *SH4, comptime T: type, virtual_addr: u32, value: T) void {
             var stdout_writer = std.Io.File.stdout().writer(SH4Module.Context.io, &stdout_buffer);
             const stdout = &stdout_writer.interface;
 
-            stdout.print("\u{001b}[44m\u{001b}[97m{c}\u{001b}[0m", .{value}) catch |err| {
-                log.err("Error writing serial output: {}\n", .{err});
-            };
+            log.debug("Serial FIFO out: {c}", .{value});
+            if (false) {
+                stdout.print("\u{001b}[44m\u{001b}[97m{c}\u{001b}[0m", .{value}) catch |err| {
+                    log.err("Error writing serial output: {}\n", .{err});
+                };
+            } else {
+                stdout.writeByte(value) catch |err| {
+                    log.err("Error writing serial output: {}\n", .{err});
+                };
+            }
             stdout.flush() catch |err| {
                 log.err("Error flushing stdout: {}\n", .{err});
             };
 
-            // Immediately mark transfer as complete.
+            // Immediately mark transfer as complete/FIFO not full.
             const status_register = self.p4_register(P4.SCFSR2, .SCFSR2);
             status_register.tdfe = true;
+            status_register.tend = true;
 
-            const control_register = self.p4_register(P4.SCSCR2, .SCSCR2);
-            const fifo_control = self.p4_register(P4.SCFCR2, .SCFCR2);
-            if (control_register.tie) {
-                log.warn("Unimplemented SCIF_TXI interrupt enabled at {d} bytes.", .{fifo_control.ttrg.bytes()});
-                // self.request_interrupt(Interrupt.SCIF_TXI);
-            }
+            update_interrupts(self);
             return;
         },
         .SCFSR2 => {
@@ -35,8 +79,16 @@ pub fn write(self: *SH4, comptime T: type, virtual_addr: u32, value: T) void {
             const val: P4.SCFSR2 = @bitCast(value);
             log.debug("Write to SCFSR2: {any}", .{val});
             // Writable bits can only be cleared.
+            // "Note: * Only 0 can be written, to clear the flag.""
             // TODO: "Also note that in order to clear these flags they must be read as 1 beforehand."
-            // self.p4_register(u16, .SCFSR2).* &= (value | 0b11111111_00001100);
+            const scfsr2 = self.p4_register(P4.SCFSR2, .SCFSR2);
+            inline for (.{ "dr", "rdf", "brk", "tdfe", "tend", "er" }) |flag| {
+                if (!@field(val, flag)) @field(scfsr2, flag) = false;
+            }
+            // Always mark transmission as complete/FIFO not full.
+            scfsr2.tdfe = true;
+            scfsr2.tend = true;
+            update_interrupts(self);
             return;
         },
         .SCFCR2 => {
@@ -46,13 +98,24 @@ pub fn write(self: *SH4, comptime T: type, virtual_addr: u32, value: T) void {
             log.debug("Write to SCFCR2: {any}", .{val});
             if (val.rfrst) log.debug("  Resetting Receive FIFO", .{});
             if (val.tfrst) log.debug("  Resetting Transmit FIFO", .{});
-            // self.p4_register(P4.SCFCR2, .SCFSR2).* = val;
+            self.p4_register(P4.SCFCR2, .SCFCR2).* = val;
             return;
         },
         else => {
             self.p4_register_addr(T, virtual_addr).* = value;
         },
     }
+}
+
+fn update_interrupts(self: *SH4) void {
+    const status_register = self.p4_register(P4.SCFSR2, .SCFSR2);
+    const line_status_register = self.p4_register(P4.SCLSR2, .SCLSR2);
+    const control_register = self.p4_register(P4.SCSCR2, .SCSCR2);
+    self.set_interrupt(SH4Module.Interrupt.SCIF_TXI, status_register.tdfe and control_register.tie);
+    self.set_interrupt(SH4Module.Interrupt.SCIF_RXI, (status_register.rdf or status_register.dr) and control_register.rie);
+    // "By setting the REIE bit to 1 while the RIE bit is cleared to 0, it is possible to output ERI and BRI interrupt requests, but not RXI interrupt requests."
+    self.set_interrupt(SH4Module.Interrupt.SCIF_BRI, (status_register.brk or line_status_register.orer) and (control_register.rie or control_register.reie));
+    self.set_interrupt(SH4Module.Interrupt.SCIF_ERI, status_register.er and (control_register.rie or control_register.reie));
 }
 
 const std = @import("std");

--- a/src/main.zig
+++ b/src/main.zig
@@ -21,7 +21,7 @@ pub const std_options: std.Options = .{
         .{ .scope = .elf, .level = .warn },
         .{ .scope = .dc, .level = .warn },
         .{ .scope = .sh4, .level = .warn },
-        .{ .scope = .sh4_scif, .level = .debug },
+        .{ .scope = .sh4_scif, .level = .info },
         .{ .scope = .mmu, .level = .info },
         .{ .scope = .sh4_jit, .level = .warn },
         .{ .scope = .arm_jit, .level = .info },

--- a/src/main.zig
+++ b/src/main.zig
@@ -21,6 +21,7 @@ pub const std_options: std.Options = .{
         .{ .scope = .elf, .level = .warn },
         .{ .scope = .dc, .level = .warn },
         .{ .scope = .sh4, .level = .warn },
+        .{ .scope = .sh4_scif, .level = .debug },
         .{ .scope = .mmu, .level = .info },
         .{ .scope = .sh4_jit, .level = .warn },
         .{ .scope = .arm_jit, .level = .info },

--- a/src/main.zig
+++ b/src/main.zig
@@ -65,6 +65,8 @@ pub fn main(init: std.process.Init) !void {
     try DreamcastModule.HostPaths.init(io, allocator, init.environ_map.*);
     defer DreamcastModule.HostPaths.deinit(allocator);
 
+    defer DreamcastModule.SH4Module.SCIF.deinit(io);
+
     if (builtin.os.tag == .windows and config.no_console) {
         // When built with the GUI subsystem on Windows, try to attach to the console if we received any arguments.
         if (init.minimal.args.vector.len > 1)
@@ -146,6 +148,8 @@ pub fn main(init: std.process.Init) !void {
                     std.log.err(termcolor.red("Invalid state number after --load-state: {d}"), .{load_state.?});
                     return error.InvalidArguments;
                 }
+            } else if (std.mem.eql(u8, arg, "--scif")) {
+                try DreamcastModule.SH4Module.SCIF.init(io);
             } else if (std.mem.eql(u8, arg, "--attach-console")) {
                 // Argument used to attach the console on Windows in GUI subsystem, see above.
             } else {


### PR DESCRIPTION
Improvements (& fixes) to SCIF.
Should allow using dcload-serial for quick prototyping.

~~Currently requires redirecting `stdout` and `stdin`: Find a better UX.~~

Launch `dcload-serial` in Deecy with `--scif`, exposing the SCIF at `/tmp/deecy/scif`.
Load an executable with `dc-tool-ser`:
```sh
dc-tool-ser -t /tmp/deecy/scif -x main.elf
```
With `/pc/` support (mounted to `.`):
```sh
sudo dc-tool-ser -t /tmp/deecy/scif -x main.elf -c .
```