### PR TITLE
Paths cleanup

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -53,18 +53,6 @@ pub fn build(b: *std.Build) !void {
     });
     dc_module.addOptions("dc_config", dc_options);
 
-    if (use_appdata_dir) {
-        if (b.lazyDependency("known_folders", .{
-            .target = target,
-            .optimize = optimize,
-        })) |known_folders| {
-            dc_module.addImport("known-folders", known_folders.module("known-folders"));
-        } else {
-            std.log.err("Option 'use_appdata_dir' requires the dependency 'known-folders'", .{});
-            return error.MissingDependency;
-        }
-    }
-
     const ziglz4 = b.dependency("ziglz4", .{
         .target = target,
         .optimize = .ReleaseFast,
@@ -100,6 +88,15 @@ pub fn build(b: *std.Build) !void {
     });
     deecy_module.addOptions("config", deecy_options);
     deecy_module.addOptions("path_config", path_options);
+
+    if (use_appdata_dir) {
+        if (b.lazyDependency("known_folders", .{
+            .target = target,
+            .optimize = optimize,
+        })) |known_folders| {
+            deecy_module.addImport("known-folders", known_folders.module("known-folders"));
+        }
+    }
 
     const exe = b.addExecutable(.{
         .name = "Deecy",

--- a/build.zig
+++ b/build.zig
@@ -52,7 +52,6 @@ pub fn build(b: *std.Build) !void {
         },
     });
     dc_module.addOptions("dc_config", dc_options);
-    dc_module.addOptions("path_config", path_options);
 
     if (use_appdata_dir) {
         if (b.lazyDependency("known_folders", .{
@@ -100,6 +99,7 @@ pub fn build(b: *std.Build) !void {
         .stack_check = false,
     });
     deecy_module.addOptions("config", deecy_options);
+    deecy_module.addOptions("path_config", path_options);
 
     const exe = b.addExecutable(.{
         .name = "Deecy",

--- a/src/GameSettings.zig
+++ b/src/GameSettings.zig
@@ -5,12 +5,10 @@ bios_emulation: ?Deecy.Configuration.BiosEmulation = null,
 rendering: @import("renderer.zig").GameSettings = .{},
 
 pub fn save(self: @This(), io: std.Io, allocator: std.mem.Allocator, product_uid: Default.ProductUID) !void {
-    const file_path = try path(allocator, product_uid);
-    defer allocator.free(file_path);
+    const dir = try host_paths.game_directory(io, allocator, product_uid);
+    defer dir.close(io);
 
-    if (std.fs.path.dirname(file_path)) |dir| try std.Io.Dir.cwd().createDirPath(io, dir);
-
-    const file = try std.Io.Dir.cwd().createFile(io, file_path, .{});
+    const file = try dir.createFile(io, SettingsFileName, .{});
     defer file.close(io);
     const buffer = try allocator.alloc(u8, 8192);
     defer allocator.free(buffer);
@@ -20,10 +18,10 @@ pub fn save(self: @This(), io: std.Io, allocator: std.mem.Allocator, product_uid
 }
 
 pub fn load(io: std.Io, allocator: std.mem.Allocator, product_uid: Default.ProductUID) !@This() {
-    const file_path = try path(allocator, product_uid);
-    defer allocator.free(file_path);
+    const dir = try host_paths.game_directory(io, allocator, product_uid);
+    defer dir.close(io);
 
-    const settings_str = std.Io.Dir.cwd().readFileAllocOptions(io, file_path, allocator, .limited(8 * 1024 * 1024), .@"8", 0) catch |err| {
+    const settings_str = dir.readFileAllocOptions(io, SettingsFileName, allocator, .limited(8 * 1024 * 1024), .@"8", 0) catch |err| {
         switch (err) {
             error.FileNotFound => {
                 if (Default.get(product_uid)) |builtin| {
@@ -38,18 +36,13 @@ pub fn load(io: std.Io, allocator: std.mem.Allocator, product_uid: Default.Produ
     defer allocator.free(settings_str);
 
     const zon = std.zon.parse.fromSlice(Partial(@This()), allocator, settings_str, null, .{ .ignore_unknown_fields = true, .free_on_error = true }) catch |err| {
-        log.err("Failed to parse game settings file '{s}': {t}.", .{ file_path, err });
+        log.err("Failed to parse game settings file for {f}: {t}.", .{ product_uid, err });
         return .{};
     };
     return helpers.to_complete(@This(), zon);
 }
 
-/// Caller owns the returned memory
-fn path(allocator: std.mem.Allocator, product_uid: Default.ProductUID) ![]const u8 {
-    const game_dir = try HostPaths.userdata_game_directory(allocator, product_uid);
-    defer allocator.free(game_dir);
-    return try std.fs.path.join(allocator, &[_][]const u8{ game_dir, "settings.zon" });
-}
+const SettingsFileName = "settings.zon";
 
 const std = @import("std");
 const log = std.log.scoped(.game_settings);
@@ -58,6 +51,5 @@ const helpers = @import("helpers");
 const Partial = helpers.Partial;
 
 const Deecy = @import("deecy.zig");
-const Dreamcast = @import("dreamcast");
-const HostPaths = @import("dreamcast").HostPaths;
+const host_paths = Deecy.host_paths;
 const Default = @import("default_game_settings.zig");

--- a/src/ProductUID.zig
+++ b/src/ProductUID.zig
@@ -9,4 +9,8 @@ pub fn eql(self: @This(), other: @This()) bool {
     return std.mem.eql(u8, self.name, other.name) and std.mem.eql(u8, self.id, other.id);
 }
 
+pub fn format(self: @This(), writer: *std.Io.Writer) !void {
+    try writer.print("'{s}' ({s})", .{ self.name, self.id });
+}
+
 const std = @import("std");

--- a/src/cheats.zig
+++ b/src/cheats.zig
@@ -1,10 +1,3 @@
-const std = @import("std");
-const log = std.log.scoped(.cheats);
-
-const HostPaths = @import("dreamcast").HostPaths;
-const Default = @import("default_game_settings.zig");
-const codebreaker = @import("codebreaker.zig");
-
 pub const Condition = enum {
     @"=",
     @"!=",
@@ -52,20 +45,11 @@ pub const Cheat = struct {
     }
 };
 
-/// Caller owns the returned memory
-pub fn path(allocator: std.mem.Allocator, uid: Default.ProductUID) ![]const u8 {
-    const game_dir = try HostPaths.userdata_game_directory(allocator, uid);
-    defer allocator.free(game_dir);
-    return try std.fs.path.join(allocator, &[_][]const u8{ game_dir, "cheats.zon" });
-}
-
 pub fn save(allocator: std.mem.Allocator, io: std.Io, product_uid: Default.ProductUID, cheats: []const Cheat) !void {
-    const cheat_path = try path(allocator, product_uid);
-    defer allocator.free(cheat_path);
+    const dir = try host_paths.game_directory(io, allocator, product_uid);
+    defer dir.close(io);
 
-    if (std.fs.path.dirname(cheat_path)) |dir| try HostPaths.root().createDirPath(io, dir);
-
-    const file = try HostPaths.root().createFile(io, cheat_path, .{});
+    const file = try dir.createFile(io, CheatsFileName, .{});
     defer file.close(io);
     const buffer = try allocator.alloc(u8, 8192);
     defer allocator.free(buffer);
@@ -76,10 +60,10 @@ pub fn save(allocator: std.mem.Allocator, io: std.Io, product_uid: Default.Produ
 
 /// Caller owns the returned memory
 pub fn load(allocator: std.mem.Allocator, io: std.Io, uid: Default.ProductUID) !?[]Cheat {
-    const cheat_path = try path(allocator, uid);
-    defer allocator.free(cheat_path);
+    const dir = try host_paths.game_directory(io, allocator, uid);
+    defer dir.close(io);
 
-    const cheats_str = HostPaths.root().readFileAllocOptions(io, cheat_path, allocator, .limited(8 * 1024 * 1024), .@"8", 0) catch |err| {
+    const cheats_str = dir.readFileAllocOptions(io, CheatsFileName, allocator, .limited(8 * 1024 * 1024), .@"8", 0) catch |err| {
         switch (err) {
             error.FileNotFound => {
                 // Load default cheats.
@@ -105,8 +89,17 @@ pub fn load(allocator: std.mem.Allocator, io: std.Io, uid: Default.ProductUID) !
     defer allocator.free(cheats_str);
 
     const zon = std.zon.parse.fromSliceAlloc([]Cheat, allocator, cheats_str, null, .{ .ignore_unknown_fields = true, .free_on_error = true }) catch |err| {
-        log.err("Failed to parse cheats file '{s}': {t}.", .{ cheat_path, err });
+        log.err("Failed to parse cheats file for {f}: {t}.", .{ uid, err });
         return &.{};
     };
     return zon;
 }
+
+const CheatsFileName = "cheats.zon";
+
+const std = @import("std");
+const log = std.log.scoped(.cheats);
+
+const host_paths = @import("host_paths.zig");
+const Default = @import("default_game_settings.zig");
+const codebreaker = @import("codebreaker.zig");

--- a/src/cheats.zig
+++ b/src/cheats.zig
@@ -63,9 +63,9 @@ pub fn save(allocator: std.mem.Allocator, io: std.Io, product_uid: Default.Produ
     const cheat_path = try path(allocator, product_uid);
     defer allocator.free(cheat_path);
 
-    if (std.fs.path.dirname(cheat_path)) |dir| try std.Io.Dir.cwd().createDirPath(io, dir);
+    if (std.fs.path.dirname(cheat_path)) |dir| try HostPaths.root().createDirPath(io, dir);
 
-    const file = try std.Io.Dir.cwd().createFile(io, cheat_path, .{});
+    const file = try HostPaths.root().createFile(io, cheat_path, .{});
     defer file.close(io);
     const buffer = try allocator.alloc(u8, 8192);
     defer allocator.free(buffer);
@@ -79,7 +79,7 @@ pub fn load(allocator: std.mem.Allocator, io: std.Io, uid: Default.ProductUID) !
     const cheat_path = try path(allocator, uid);
     defer allocator.free(cheat_path);
 
-    const cheats_str = std.Io.Dir.cwd().readFileAllocOptions(io, cheat_path, allocator, .limited(8 * 1024 * 1024), .@"8", 0) catch |err| {
+    const cheats_str = HostPaths.root().readFileAllocOptions(io, cheat_path, allocator, .limited(8 * 1024 * 1024), .@"8", 0) catch |err| {
         switch (err) {
             error.FileNotFound => {
                 // Load default cheats.

--- a/src/custom_log.zig
+++ b/src/custom_log.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const termcolor = @import("termcolor");
-const file = @import("log_file.zig");
+pub const file = @import("log_file.zig");
 
 pub const Output = enum { None, Console, File, Both };
 
@@ -13,11 +13,9 @@ var last_message: struct {
 var count: u32 = 0;
 var buffer: [128]u8 = undefined;
 
-var allocator: std.mem.Allocator = undefined;
 var io: std.Io = undefined;
 
-pub fn init(_io: std.Io, _allocator: std.mem.Allocator) void {
-    allocator = _allocator;
+pub fn init(_io: std.Io) void {
     io = _io;
 }
 
@@ -25,16 +23,14 @@ pub fn deinit() void {
     file.close();
 }
 
-pub const get_path = file.get_path;
-
 pub fn set_output(out: Output) void {
     if (out == output) return;
     file.close();
     output = out;
     if (output == .File or output == .Both) {
-        file.open(allocator, io) catch {
+        file.open(io) catch |err| {
             output = .Console;
-            std.log.err("Failed to open log file. That's akward...", .{});
+            std.log.err("Failed to open log file: {t}", .{err});
         };
     }
 }

--- a/src/debug_ui.zig
+++ b/src/debug_ui.zig
@@ -474,7 +474,7 @@ pub fn draw(self: *@This(), d: *Deecy) !void {
             const was_running = d.running;
             if (was_running)
                 d.pause();
-            var file = try std.Io.Dir.cwd().createFile(d.io, "logs/dc_dump.bin", .{});
+            var file = try DreamcastModule.HostPaths.root().createFile(d.io, "logs/dc_dump.bin", .{});
             defer file.close(d.io);
             const buff = try self._allocator.alloc(u8, 8192);
             var file_writer = file.writer(d.io, buff);

--- a/src/debug_ui.zig
+++ b/src/debug_ui.zig
@@ -474,7 +474,7 @@ pub fn draw(self: *@This(), d: *Deecy) !void {
             const was_running = d.running;
             if (was_running)
                 d.pause();
-            var file = try DreamcastModule.HostPaths.root().createFile(d.io, "logs/dc_dump.bin", .{});
+            var file = try Deecy.host_paths.root().createFile(d.io, "logs/dc_dump.bin", .{});
             defer file.close(d.io);
             const buff = try self._allocator.alloc(u8, 8192);
             var file_writer = file.writer(d.io, buff);

--- a/src/deecy.zig
+++ b/src/deecy.zig
@@ -29,8 +29,6 @@ const DreamcastModule = @import("dreamcast");
 const Dreamcast = DreamcastModule.Dreamcast;
 const AICA = DreamcastModule.AICAModule.AICA;
 const Disc = DreamcastModule.GDROM.Disc;
-pub const HostPaths = DreamcastModule.HostPaths;
-const ProductUID = DreamcastModule.ProductUID;
 const PreciseSleep = @import("precise_sleep.zig");
 
 pub const RendererModule = @import("./renderer.zig");
@@ -43,6 +41,8 @@ const DebugUI = @import("./debug_ui.zig");
 const Shortcuts = @import("./ui/shortcuts.zig");
 const ELF = @import("elf.zig");
 
+pub const host_paths = @import("host_paths.zig");
+const ProductUID = @import("ProductUID.zig");
 const Cheats = @import("./cheats.zig");
 const GameSettings = @import("./GameSettings.zig");
 
@@ -162,7 +162,7 @@ const DefaultFont = @embedFile(assets_dir ++ "fonts/Hack-Regular.ttf");
 const IconFont = @embedFile(assets_dir ++ "fonts/Font Awesome 7 Free-Solid-900.otf");
 
 fn file_exists(io: std.Io, path: []const u8) !bool {
-    HostPaths.root().access(io, path, .{}) catch |err| switch (err) {
+    host_paths.root().access(io, path, .{}) catch |err| switch (err) {
         error.FileNotFound => return false,
         else => return err,
     };
@@ -470,9 +470,9 @@ pub fn create(allocator: std.mem.Allocator, io: std.Io, flags: packed struct { w
 
     // Load user config
     const config: Configuration = config: {
-        const config_path = try std.fs.path.join(allocator, &[_][]const u8{ HostPaths.get_userdata_path(), ConfigFile });
+        const config_path = try std.fs.path.join(allocator, &[_][]const u8{ host_paths.get_userdata_path(), ConfigFile });
         defer allocator.free(config_path);
-        if (HostPaths.root().readFileAllocOptions(io, config_path, allocator, .limited(1024 * 1024), .@"8", 0)) |conf_str| {
+        if (host_paths.root().readFileAllocOptions(io, config_path, allocator, .limited(1024 * 1024), .@"8", 0)) |conf_str| {
             defer allocator.free(conf_str);
             @setEvalBranchQuota(2000);
             const zon = std.zon.parse.fromSliceAlloc(helpers.Partial(Configuration), allocator, conf_str, null, .{ .ignore_unknown_fields = true, .free_on_error = true }) catch |err| {
@@ -626,28 +626,34 @@ pub fn create(allocator: std.mem.Allocator, io: std.Io, flags: packed struct { w
     {
         const dc_init_time = std.Io.Clock.awake.now(self.io);
         defer deecy_log.info("Dreamcast initialized in {f}", .{dc_init_time.durationTo(std.Io.Clock.awake.now(self.io))});
+
+        const boot_rom_path = try std.fs.path.join(self._allocator, &[_][]const u8{ host_paths.get_data_path(), "dc_boot.bin" });
+        defer self._allocator.free(boot_rom_path);
+        const flash_path = try std.fs.path.join(self._allocator, &[_][]const u8{ host_paths.get_data_path(), "dc_flash.bin" });
+        defer self._allocator.free(flash_path);
+
         self.dc = while (true) {
-            if (Dreamcast.create(allocator, self.io)) |dc| break dc else |err| {
+            if (Dreamcast.create(allocator, self.io, boot_rom_path)) |dc| break dc else |err| {
                 switch (err) {
                     error.BiosNotFound => if (try self.display_missing_file_error("dc_boot.bin", 2 * 1024 * 1024,
                         \\Missing BIOS.
                         \\Please copy your bios file as 'dc_boot.bin' to '{s}'.
                         \\
                         \\(Error: {t})
-                    , .{ HostPaths.get_data_path(), err }) == .retry) continue,
+                    , .{ host_paths.get_data_path(), err }) == .retry) continue,
                     else => self.display_unrecoverable_error("Error initializing Dreamcast: {t}", .{err}),
                 }
                 return err;
             }
         };
         while (true) {
-            self.dc.load_flash(self.io, config.region.to_dreamcast(), config.bios_config) catch |err| {
+            self.dc.load_flash(self.io, flash_path, config.region.to_dreamcast(), config.bios_config) catch |err| {
                 if (try self.display_missing_file_error("dc_flash.bin", 128 * 1024,
                     \\Missing Flash.
                     \\Please copy your flash file as 'dc_flash.bin' to '{s}'.
                     \\ 
                     \\(Error: {t})
-                , .{ HostPaths.get_data_path(), err }) == .retry) continue;
+                , .{ host_paths.get_data_path(), err }) == .retry) continue;
                 return err;
             };
             break;
@@ -898,7 +904,7 @@ pub fn deinit_peripheral(self: *@This(), controller_idx: u8, slot: u8) void {
             if (e.subperipherals[slot]) |*peripheral| {
                 if (slot == 0 and peripheral.* == .VMU)
                     self.ui.vmu_displays[controller_idx].valid = false;
-                peripheral.deinit(self._allocator);
+                peripheral.deinit(self.io, self._allocator);
             }
             e.subperipherals[slot] = null;
         },
@@ -957,7 +963,7 @@ pub fn init_peripheral(self: *@This(), port: u8, slot: u8) !void {
     switch (self.config.controllers[port].subperipherals[slot]) {
         .None => {},
         .VMU => |vmu| {
-            const vmu_path = try std.fs.path.join(self._allocator, &[_][]const u8{ HostPaths.get_userdata_path(), vmu.filename });
+            const vmu_path = try std.fs.path.join(self._allocator, &[_][]const u8{ host_paths.get_userdata_path(), vmu.filename });
             defer self._allocator.free(vmu_path);
             try self.load_vmu(port, slot, vmu_path);
         },
@@ -982,7 +988,7 @@ pub fn init_peripheral(self: *@This(), port: u8, slot: u8) !void {
 
 pub fn load_per_game_vmu(self: *@This()) !void {
     if (self.dc.gdrom.disc != null) {
-        const game_dir = try self.userdata_game_directory();
+        const game_dir = try self.game_directory_path();
         defer self._allocator.free(game_dir);
         const vmu_path = try std.fs.path.join(self._allocator, &[_][]const u8{ game_dir, "vmu_0.bin" });
         defer self._allocator.free(vmu_path);
@@ -1000,7 +1006,7 @@ pub fn load_vmu(self: *@This(), port: u8, slot: u8, vmu_path: []const u8) !void 
 
     switch (self.dc.maple.ports[port]) {
         .emulated => |*e| {
-            e.subperipherals[slot] = .{ .VMU = try .init(self._allocator, vmu_path) };
+            e.subperipherals[slot] = .{ .VMU = try .init(self.io, self._allocator, vmu_path) };
             if (slot == 0) {
                 e.subperipherals[slot].?.VMU.on_screen_update = .{ .function = @ptrCast(&switch (port) {
                     inline 0, 1, 2, 3 => |pidx| UI.vmu_screen_callback(pidx).callback,
@@ -1057,7 +1063,7 @@ pub fn enable_port(self: *@This(), port: u8, value: bool) !void {
         }
     } else {
         self.ui.vmu_displays[port].valid = false;
-        self.dc.maple.ports[port].deinit(self._allocator);
+        self.dc.maple.ports[port].deinit(self.io, self._allocator);
         self.dc.maple.ports[port] = .none;
     }
     config.enabled = value;
@@ -1092,7 +1098,7 @@ pub fn stop(self: *@This()) !void {
 pub fn update(self: *@This(), delta_time: f32) void {
     self.update_rumble(delta_time);
     self.poll_controllers();
-    self.dc.maple.flush_vmus();
+    self.dc.maple.flush_vmus(self.io);
     if (self._stop_request) {
         self.pause();
         self._stop_request = false;
@@ -1372,7 +1378,9 @@ pub fn load_disc(self: *@This(), path: []const u8) !void {
 
     deecy_log.info("Using settings: Region={t}, Video Cable={t}, Bios Emulation={t}", .{ region, video_cable, bios_emulation });
 
-    self.dc.load_flash(self.io, region, self.config.bios_config) catch |err| {
+    const flash_path = try std.fs.path.join(self._allocator, &[_][]const u8{ host_paths.get_data_path(), "dc_flash.bin" });
+    defer self._allocator.free(flash_path);
+    self.dc.load_flash(self.io, flash_path, region, self.config.bios_config) catch |err| {
         switch (err) {
             error.FileNotFound => return error.MissingFlash,
             else => return err,
@@ -1523,13 +1531,13 @@ pub fn product_uid(self: *const @This()) ProductUID {
 
 /// Game specific sub directory name (for VMUs, save states...)
 /// Caller owns the returned string.
-fn userdata_game_directory(self: *const @This()) ![]const u8 {
-    return HostPaths.userdata_game_directory(self._allocator, self.product_uid());
+fn game_directory_path(self: *const @This()) ![]const u8 {
+    return host_paths.game_directory_path(self._allocator, self.product_uid());
 }
 
 /// Caller owns the returned string
 fn save_state_path(self: *const @This(), index: usize) ![]const u8 {
-    const game_dir = try self.userdata_game_directory();
+    const game_dir = try self.game_directory_path();
     defer self._allocator.free(game_dir);
     var buf: [32]u8 = undefined;
     const file_name = try std.fmt.bufPrint(&buf, "save_{d}.sav", .{index});
@@ -1658,7 +1666,7 @@ pub fn pause(self: *@This()) void {
             self._dc_thread = null;
         }
         if (self.audio_input) |ai| ai.device.stop() catch |err| deecy_log.err(termcolor.red("Failed to stop audio device: {}"), .{err});
-        self.dc.maple.flush_vmus();
+        self.dc.maple.flush_vmus(self.io);
 
         if (self.config.rewind.enabled) {
             if (self.renderer.render_request) |*rr|
@@ -1926,7 +1934,7 @@ fn display_missing_file_error(self: *@This(), filename: []const u8, expected_siz
                             .linux => "xdg-open",
                             .macos => "open",
                             else => @compileError("Unsupported OS"),
-                        }, HostPaths.get_data_path() },
+                        }, host_paths.get_data_path() },
                     },
                 );
                 _ = try file_explorer.wait(self.io);
@@ -1957,7 +1965,7 @@ fn copy_file(io: std.Io, filename: []const u8, expected_size: ?usize) !bool {
             const stat = try std.Io.Dir.cwd().statFile(io, path, .{});
             if (es != stat.size) return error.@"Unexpected File Size";
         }
-        try HostPaths.root().copyFile(path, HostPaths.data(), filename, io, .{});
+        try host_paths.root().copyFile(path, host_paths.data(), filename, io, .{});
         return true;
     }
 
@@ -2078,12 +2086,12 @@ fn save_screenshot_impl(self: *const @This()) !void {
         day_seconds.getSecondsIntoMinute(),
     });
     defer self._allocator.free(filepath);
-    HostPaths.safe_path(filepath);
+    host_paths.safe_path(filepath);
 
     // Make sure the directory exists.
     if (std.fs.path.dirname(filepath)) |dir|
-        try HostPaths.root().createDirPath(self.io, dir);
-    var file = try HostPaths.root().createFile(self.io, filepath, .{});
+        try host_paths.root().createDirPath(self.io, dir);
+    var file = try host_paths.root().createFile(self.io, filepath, .{});
     defer file.close(self.io);
 
     var buffer: [1024]u8 = undefined;
@@ -2184,9 +2192,9 @@ fn compress_and_dump_save_state(self: *@This(), index: usize, uncompressed_array
     defer self._allocator.free(save_slot_path);
 
     if (std.fs.path.dirname(save_slot_path)) |dirname|
-        try HostPaths.root().createDirPath(self.io, dirname);
+        try host_paths.root().createDirPath(self.io, dirname);
 
-    var file = try HostPaths.root().createFile(self.io, save_slot_path, .{});
+    var file = try host_paths.root().createFile(self.io, save_slot_path, .{});
     defer file.close(self.io);
     var buffer: [1024]u8 = undefined;
     var writer = file.writer(self.io, &buffer);
@@ -2218,7 +2226,7 @@ pub fn load_state(self: *@This(), index: usize) !void {
 
     const start_time = std.Io.Timestamp.now(self.io, .awake);
 
-    const file = try HostPaths.root().readFileAllocOptions(self.io, save_slot_path, self._allocator, .limited(32 * 1024 * 1024), .@"8", null);
+    const file = try host_paths.root().readFileAllocOptions(self.io, save_slot_path, self._allocator, .limited(32 * 1024 * 1024), .@"8", null);
     defer self._allocator.free(file);
 
     const header = std.mem.bytesToValue(SaveStateHeader, file[0..@sizeOf(SaveStateHeader)]);
@@ -2245,9 +2253,9 @@ fn deserialize(self: *@This(), serialized: []const u8) !void {
 }
 
 fn save_config(self: *@This()) !void {
-    const config_path = try std.fs.path.join(self._allocator, &[_][]const u8{ HostPaths.get_userdata_path(), ConfigFile });
+    const config_path = try std.fs.path.join(self._allocator, &[_][]const u8{ host_paths.get_userdata_path(), ConfigFile });
     defer self._allocator.free(config_path);
-    var config_file = try HostPaths.root().createFile(self.io, config_path, .{});
+    var config_file = try host_paths.root().createFile(self.io, config_path, .{});
     defer config_file.close(self.io);
     const buffer = try self._allocator.alloc(u8, 8192);
     defer self._allocator.free(buffer);

--- a/src/deecy.zig
+++ b/src/deecy.zig
@@ -162,7 +162,7 @@ const DefaultFont = @embedFile(assets_dir ++ "fonts/Hack-Regular.ttf");
 const IconFont = @embedFile(assets_dir ++ "fonts/Font Awesome 7 Free-Solid-900.otf");
 
 fn file_exists(io: std.Io, path: []const u8) !bool {
-    std.Io.Dir.cwd().access(io, path, .{}) catch |err| switch (err) {
+    HostPaths.root().access(io, path, .{}) catch |err| switch (err) {
         error.FileNotFound => return false,
         else => return err,
     };
@@ -468,16 +468,11 @@ pub fn create(allocator: std.mem.Allocator, io: std.Io, flags: packed struct { w
     const start_time = std.Io.Clock.awake.now(io);
     defer deecy_log.info("Deecy initialized in {f}", .{start_time.durationTo(std.Io.Clock.awake.now(io))});
 
-    std.Io.Dir.cwd().createDirPath(io, HostPaths.get_userdata_path()) catch |err| switch (err) {
-        error.PathAlreadyExists => {},
-        else => return err,
-    };
-
     // Load user config
     const config: Configuration = config: {
         const config_path = try std.fs.path.join(allocator, &[_][]const u8{ HostPaths.get_userdata_path(), ConfigFile });
         defer allocator.free(config_path);
-        if (std.Io.Dir.cwd().readFileAllocOptions(io, config_path, allocator, .limited(1024 * 1024), .@"8", 0)) |conf_str| {
+        if (HostPaths.root().readFileAllocOptions(io, config_path, allocator, .limited(1024 * 1024), .@"8", 0)) |conf_str| {
             defer allocator.free(conf_str);
             @setEvalBranchQuota(2000);
             const zon = std.zon.parse.fromSliceAlloc(helpers.Partial(Configuration), allocator, conf_str, null, .{ .ignore_unknown_fields = true, .free_on_error = true }) catch |err| {
@@ -1923,8 +1918,6 @@ fn display_missing_file_error(self: *@This(), filename: []const u8, expected_siz
             }
             zgui.sameLine(.{});
             if (zgui.button(UI.Icons.Folder ++ " Open folder", .{})) {
-                const absolute_path = try std.Io.Dir.cwd().realPathFileAlloc(self.io, HostPaths.get_data_path(), self._allocator);
-                defer self._allocator.free(absolute_path);
                 var file_explorer = try std.process.spawn(
                     self.io,
                     .{
@@ -1933,7 +1926,7 @@ fn display_missing_file_error(self: *@This(), filename: []const u8, expected_siz
                             .linux => "xdg-open",
                             .macos => "open",
                             else => @compileError("Unsupported OS"),
-                        }, absolute_path },
+                        }, HostPaths.get_data_path() },
                     },
                 );
                 _ = try file_explorer.wait(self.io);
@@ -1964,9 +1957,7 @@ fn copy_file(io: std.Io, filename: []const u8, expected_size: ?usize) !bool {
             const stat = try std.Io.Dir.cwd().statFile(io, path, .{});
             if (es != stat.size) return error.@"Unexpected File Size";
         }
-        const dest_dir = try std.Io.Dir.cwd().openDir(io, HostPaths.get_data_path(), .{});
-        defer dest_dir.close(io);
-        try std.Io.Dir.cwd().copyFile(path, dest_dir, filename, io, .{});
+        try HostPaths.root().copyFile(path, HostPaths.data(), filename, io, .{});
         return true;
     }
 
@@ -2091,8 +2082,8 @@ fn save_screenshot_impl(self: *const @This()) !void {
 
     // Make sure the directory exists.
     if (std.fs.path.dirname(filepath)) |dir|
-        try std.Io.Dir.cwd().createDirPath(self.io, dir);
-    var file = try std.Io.Dir.cwd().createFile(self.io, filepath, .{});
+        try HostPaths.root().createDirPath(self.io, dir);
+    var file = try HostPaths.root().createFile(self.io, filepath, .{});
     defer file.close(self.io);
 
     var buffer: [1024]u8 = undefined;
@@ -2193,9 +2184,9 @@ fn compress_and_dump_save_state(self: *@This(), index: usize, uncompressed_array
     defer self._allocator.free(save_slot_path);
 
     if (std.fs.path.dirname(save_slot_path)) |dirname|
-        try std.Io.Dir.cwd().createDirPath(self.io, dirname);
+        try HostPaths.root().createDirPath(self.io, dirname);
 
-    var file = try std.Io.Dir.cwd().createFile(self.io, save_slot_path, .{});
+    var file = try HostPaths.root().createFile(self.io, save_slot_path, .{});
     defer file.close(self.io);
     var buffer: [1024]u8 = undefined;
     var writer = file.writer(self.io, &buffer);
@@ -2227,7 +2218,7 @@ pub fn load_state(self: *@This(), index: usize) !void {
 
     const start_time = std.Io.Timestamp.now(self.io, .awake);
 
-    const file = try std.Io.Dir.cwd().readFileAllocOptions(self.io, save_slot_path, self._allocator, .limited(32 * 1024 * 1024), .@"8", null);
+    const file = try HostPaths.root().readFileAllocOptions(self.io, save_slot_path, self._allocator, .limited(32 * 1024 * 1024), .@"8", null);
     defer self._allocator.free(file);
 
     const header = std.mem.bytesToValue(SaveStateHeader, file[0..@sizeOf(SaveStateHeader)]);
@@ -2256,7 +2247,7 @@ fn deserialize(self: *@This(), serialized: []const u8) !void {
 fn save_config(self: *@This()) !void {
     const config_path = try std.fs.path.join(self._allocator, &[_][]const u8{ HostPaths.get_userdata_path(), ConfigFile });
     defer self._allocator.free(config_path);
-    var config_file = try std.Io.Dir.cwd().createFile(self.io, config_path, .{});
+    var config_file = try HostPaths.root().createFile(self.io, config_path, .{});
     defer config_file.close(self.io);
     const buffer = try self._allocator.alloc(u8, 8192);
     defer self._allocator.free(buffer);

--- a/src/deecy_ui.zig
+++ b/src/deecy_ui.zig
@@ -15,7 +15,7 @@ const ui_log = std.log.scoped(.ui);
 const nfd = @import("nfd");
 
 const Deecy = @import("deecy.zig");
-const HostPaths = Deecy.HostPaths;
+const host_paths = Deecy.host_paths;
 const DreamcastModule = @import("dreamcast");
 const MapleModule = DreamcastModule.Maple;
 const Disc = DreamcastModule.GDROM.Disc;
@@ -362,11 +362,11 @@ const GameInfoCache = struct {
     }
 
     fn get_path(allocator: std.mem.Allocator) ![]const u8 {
-        return try std.fs.path.join(allocator, &[_][]const u8{ HostPaths.get_userdata_path(), "game_info_cache" });
+        return try std.fs.path.join(allocator, &[_][]const u8{ host_paths.get_userdata_path(), "game_info_cache" });
     }
 
     pub fn load(self: *@This(), io: std.Io) !void {
-        const data = try HostPaths.root().readFileAlloc(io, self._path, self._arena.allocator(), .unlimited);
+        const data = try host_paths.root().readFileAlloc(io, self._path, self._arena.allocator(), .unlimited);
         defer self._arena.allocator().free(data);
         try self.deserialize(data);
     }
@@ -396,7 +396,7 @@ const GameInfoCache = struct {
     }
 
     pub fn save_to_disk(self: *@This(), io: std.Io) !void {
-        var file = try HostPaths.root().createFile(io, self._path, .{});
+        var file = try host_paths.root().createFile(io, self._path, .{});
         defer file.close(io);
 
         var allocating_writer = std.Io.Writer.Allocating.init(self._arena.allocator());
@@ -508,7 +508,7 @@ pub fn refresh_games(self: *@This()) !void {
             var tmp_disc_files: std.ArrayList(GameFile) = .empty;
             errdefer tmp_disc_files.deinit(self.allocator);
 
-            var dir = HostPaths.root().openDir(self.deecy.io, dir_path, .{ .iterate = true }) catch |err| {
+            var dir = host_paths.root().openDir(self.deecy.io, dir_path, .{ .iterate = true }) catch |err| {
                 ui_log.err(termcolor.red("Failed to open game directory: {t}"), .{err});
                 return;
             };
@@ -622,7 +622,7 @@ pub fn draw(self: *@This()) !void {
                 if (zgui.menuItem("File", .{ .selected = d.config.log_output == .File }))
                     d.config.log_output = .File;
                 if (zgui.isItemHovered(.{ .for_tooltip = true }) and zgui.beginTooltip()) {
-                    const path = try custom_log.get_path(d._allocator);
+                    const path = try custom_log.file.path(d._allocator);
                     defer d._allocator.free(path);
                     zgui.text("Logs will be saved in '{s}'", .{path});
                     zgui.endTooltip();
@@ -845,8 +845,11 @@ pub fn draw(self: *@This()) !void {
                             flash_updated = zgui.comboFromEnum("Sound Mode", &d.config.bios_config.sound_mode) or flash_updated;
                             flash_updated = zgui.comboFromEnum("Auto Start", &d.config.bios_config.auto_start) or flash_updated;
                         }
-                        if (flash_updated)
-                            try d.dc.load_flash(d.io, d.config.region.to_dreamcast(), d.config.bios_config);
+                        if (flash_updated) {
+                            const flash_path = try std.fs.path.join(d._allocator, &[_][]const u8{ host_paths.get_data_path(), "dc_flash.bin" });
+                            defer d._allocator.free(flash_path);
+                            try d.dc.load_flash(d.io, flash_path, d.config.region.to_dreamcast(), d.config.bios_config);
+                        }
                     }
                     {
                         zgui.separatorText("Rewind");

--- a/src/deecy_ui.zig
+++ b/src/deecy_ui.zig
@@ -366,7 +366,7 @@ const GameInfoCache = struct {
     }
 
     pub fn load(self: *@This(), io: std.Io) !void {
-        const data = try std.Io.Dir.cwd().readFileAlloc(io, self._path, self._arena.allocator(), .unlimited);
+        const data = try HostPaths.root().readFileAlloc(io, self._path, self._arena.allocator(), .unlimited);
         defer self._arena.allocator().free(data);
         try self.deserialize(data);
     }
@@ -396,7 +396,7 @@ const GameInfoCache = struct {
     }
 
     pub fn save_to_disk(self: *@This(), io: std.Io) !void {
-        var file = try std.Io.Dir.cwd().createFile(io, self._path, .{});
+        var file = try HostPaths.root().createFile(io, self._path, .{});
         defer file.close(io);
 
         var allocating_writer = std.Io.Writer.Allocating.init(self._arena.allocator());
@@ -508,7 +508,7 @@ pub fn refresh_games(self: *@This()) !void {
             var tmp_disc_files: std.ArrayList(GameFile) = .empty;
             errdefer tmp_disc_files.deinit(self.allocator);
 
-            var dir = std.Io.Dir.cwd().openDir(self.deecy.io, dir_path, .{ .iterate = true }) catch |err| {
+            var dir = HostPaths.root().openDir(self.deecy.io, dir_path, .{ .iterate = true }) catch |err| {
                 ui_log.err(termcolor.red("Failed to open game directory: {t}"), .{err});
                 return;
             };

--- a/src/deecy_ui.zig
+++ b/src/deecy_ui.zig
@@ -1153,7 +1153,9 @@ pub fn draw(self: *@This()) !void {
                                                 if (e.subperipherals[slot]) |*s| {
                                                     switch (s.*) {
                                                         .VMU => |vmu| {
-                                                            zgui.textDisabled("Loaded: {s}", .{vmu.backing_file_path});
+                                                            zgui.pushStyleColor1u(.{ .idx = .text, .c = 0xFF808080 });
+                                                            zgui.textWrapped("Loaded: '{s}'", .{vmu.backing_file_path});
+                                                            zgui.popStyleColor(.{});
                                                             if (d.config.controllers[port].subperipherals[slot] == .VMU) {
                                                                 const vmu_config = &d.config.controllers[port].subperipherals[slot].VMU;
                                                                 if (vmu_config.filename.len < static.VMUFilenamesInputBuffers[port][slot].len - 1) {

--- a/src/default_game_settings.zig
+++ b/src/default_game_settings.zig
@@ -41,5 +41,4 @@ const builtin = @import("builtin");
 const cheats = @import("cheats.zig");
 const GameSettings = @import("GameSettings.zig");
 const Partial = @import("helpers").Partial;
-const HostPaths = @import("dreamcast").HostPaths;
-pub const ProductUID = @import("dreamcast").ProductUID;
+pub const ProductUID = @import("ProductUID.zig");

--- a/src/dreamcast/dreamcast.zig
+++ b/src/dreamcast/dreamcast.zig
@@ -6,7 +6,6 @@ const UpTo = @import("helpers").UpTo;
 const termcolor = @import("termcolor");
 const log = std.log.scoped(.dc);
 
-pub const HostPaths = @import("host_paths.zig");
 pub const Context = struct {
     pub var io: std.Io = std.Io.failing;
 };
@@ -51,8 +50,6 @@ pub const CableType = enum(u16) {
     RGB = 2,
     Composite = 3,
 };
-
-pub const ProductUID = @import("ProductUID.zig");
 
 pub const AICASync = enum { @"1 ARM Cycle", @"4 ARM Cycles", @"8 ARM Cycles", @"16 ARM Cycles", @"32 ARM Cycles", Sample };
 
@@ -137,7 +134,7 @@ pub const Dreamcast = struct {
     cpu: SH4,
     gpu: Holly = undefined,
     aica: AICA = undefined,
-    maple: MapleHost,
+    maple: MapleHost = .init,
     gdrom: GDROM = undefined,
     gdrom_hle: GDROM_HLE = .{}, // NOTE: Currently not serialized in save states. It is now less compatible than the LLE implementation.
 
@@ -170,13 +167,12 @@ pub const Dreamcast = struct {
 
     _dummy: [4]u8 align(32) = @splat(0), // FIXME: Dummy space for non-implemented features
 
-    pub fn create(allocator: std.mem.Allocator, io: std.Io) !*Dreamcast {
+    pub fn create(allocator: std.mem.Allocator, io: std.Io, boot_rom_path: []const u8) !*Dreamcast {
         Context.io = io;
 
         const dc = try allocator.create(Dreamcast);
         dc.* = Dreamcast{
             .cpu = try .init(allocator, dc),
-            .maple = try .init(allocator),
             .flash = try .init(allocator),
             .hardware_registers = try allocator.allocWithOptions(u8, 0x20_0000, .@"4", null), // FIXME: Huge waste of memory.
             ._allocator = allocator,
@@ -203,7 +199,7 @@ pub const Dreamcast = struct {
 
         errdefer dc.destroy();
 
-        dc.load_bios(Context.io, "dc_boot.bin") catch |err| {
+        dc.load_bios(io, boot_rom_path) catch |err| {
             switch (err) {
                 error.FileNotFound => return error.BiosNotFound,
                 else => return err,
@@ -240,7 +236,7 @@ pub const Dreamcast = struct {
         self.scheduled_events.deinit(self._allocator);
         self.sh4_jit.deinit();
         self.gdrom.deinit(Context.io);
-        self.maple.deinit();
+        self.maple.deinit(Context.io, self._allocator);
         self.aica.deinit();
         self.gpu.deinit();
         self.cpu.deinit();
@@ -307,29 +303,15 @@ pub const Dreamcast = struct {
         self.hw_register(u32, .SB_TFREM).* = 8;
     }
 
-    pub fn load_bios(self: *@This(), io: std.Io, boot_path: []const u8) !void {
-        if ((try HostPaths.data().readFile(io, boot_path, self.boot)).len != 0x200000)
+    fn load_bios(self: *@This(), io: std.Io, boot_path: []const u8) !void {
+        if ((try std.Io.Dir.cwd().readFile(io, boot_path, self.boot)).len != 0x200000)
             return error.InvalidBootROMSize;
     }
 
     pub const BiosConfig = struct { language: Language = .English, sound_mode: Flash.SystemConfigPayload.SoundMode = .Stereo, auto_start: Flash.SystemConfigPayload.AutoStart = .On };
 
-    pub fn load_flash(self: *@This(), io: std.Io, region: Region, bios_config: BiosConfig) !void {
-        // FIXME: User flash is sometimes corrupted. Always load default until I understand what's going on.
-        if ((try HostPaths.data().readFile(io, "dc_flash.bin", self.flash.data)).len != 0x20000) return error.InvalidFlashSize;
-
-        // var flash_file = std.fs.cwd().openFile(get_user_flash_path(), .{}) catch |err| f: {
-        //     if (err == error.FileNotFound) {
-        //         dc_log.info("Loading default flash ROM.", .{});
-        //         break :f std.fs.cwd().openFile(default_flash_path, .{}) catch |e| {
-        //             dc_log.err(termcolor.red("Failed to open default flash file at '{s}', error: {t}."), .{ default_flash_path, e });
-        //             return e;
-        //         };
-        //     } else {
-        //         dc_log.err(termcolor.red("Failed to open user flash file at '{s}', error: {t}."), .{ get_user_flash_path(), err });
-        //         return err;
-        //     }
-        // };
+    pub fn load_flash(self: *@This(), io: std.Io, path: []const u8, region: Region, bios_config: BiosConfig) !void {
+        if ((try std.Io.Dir.cwd().readFile(io, path, self.flash.data)).len != 0x20000) return error.InvalidFlashSize;
 
         // Some flash dumps floating around are missing some partition headers (not fully formatted, I guess).
         const PartitionHeader: []const u8 = "KATANA_FLASH____";

--- a/src/dreamcast/dreamcast.zig
+++ b/src/dreamcast/dreamcast.zig
@@ -203,12 +203,7 @@ pub const Dreamcast = struct {
 
         errdefer dc.destroy();
 
-        // Create 'userdata' folder if it doesn't exist
-        try std.Io.Dir.cwd().createDirPath(Context.io, HostPaths.get_userdata_path());
-
-        const bios_path = try std.fs.path.join(allocator, &[_][]const u8{ HostPaths.get_data_path(), "dc_boot.bin" });
-        defer allocator.free(bios_path);
-        dc.load_bios(bios_path) catch |err| {
+        dc.load_bios(Context.io, "dc_boot.bin") catch |err| {
             switch (err) {
                 error.FileNotFound => return error.BiosNotFound,
                 else => return err,
@@ -312,8 +307,8 @@ pub const Dreamcast = struct {
         self.hw_register(u32, .SB_TFREM).* = 8;
     }
 
-    pub fn load_bios(self: *@This(), boot_path: []const u8) !void {
-        if ((try std.Io.Dir.cwd().readFile(Context.io, boot_path, self.boot)).len != 0x200000)
+    pub fn load_bios(self: *@This(), io: std.Io, boot_path: []const u8) !void {
+        if ((try HostPaths.data().readFile(io, boot_path, self.boot)).len != 0x200000)
             return error.InvalidBootROMSize;
     }
 
@@ -321,8 +316,7 @@ pub const Dreamcast = struct {
 
     pub fn load_flash(self: *@This(), io: std.Io, region: Region, bios_config: BiosConfig) !void {
         // FIXME: User flash is sometimes corrupted. Always load default until I understand what's going on.
-        const default_flash_path = try std.fs.path.join(self._allocator, &[_][]const u8{ HostPaths.get_data_path(), "dc_flash.bin" });
-        defer self._allocator.free(default_flash_path);
+        if ((try HostPaths.data().readFile(io, "dc_flash.bin", self.flash.data)).len != 0x20000) return error.InvalidFlashSize;
 
         // var flash_file = std.fs.cwd().openFile(get_user_flash_path(), .{}) catch |err| f: {
         //     if (err == error.FileNotFound) {
@@ -336,8 +330,6 @@ pub const Dreamcast = struct {
         //         return err;
         //     }
         // };
-
-        if ((try std.Io.Dir.cwd().readFile(io, default_flash_path, self.flash.data)).len != 0x20000) return error.InvalidFlashSize;
 
         // Some flash dumps floating around are missing some partition headers (not fully formatted, I guess).
         const PartitionHeader: []const u8 = "KATANA_FLASH____";

--- a/src/dreamcast/host_paths.zig
+++ b/src/dreamcast/host_paths.zig
@@ -1,8 +1,13 @@
 var data_path: []const u8 = "";
 var userdata_path: []const u8 = "";
 
+var root_dir: std.Io.Dir = undefined;
+var data_dir: std.Io.Dir = undefined;
+var userdata_dir: std.Io.Dir = undefined;
+
 pub fn init(io: std.Io, allocator: std.mem.Allocator, environ: std.process.Environ.Map) !void {
-    if (path_config.use_appdata_dir) {
+    var path_buffer: [std.fs.max_path_bytes]u8 = undefined;
+    const deecy_folder = if (path_config.use_appdata_dir) dir: {
         const app_data_dir = try known_folders.getPath(io, allocator, environ, .local_configuration) orelse {
             std.log.warn("No known 'local_configuration' folder.", .{});
             return error.MissingKnownFolder;
@@ -13,20 +18,54 @@ pub fn init(io: std.Io, allocator: std.mem.Allocator, environ: std.process.Envir
         defer allocator.free(deecy_folder);
         std.log.info("Using App data folder as '{s}'", .{deecy_folder});
 
-        data_path = try std.fs.path.resolve(allocator, &[_][]const u8{ deecy_folder, path_config.data_path });
-        userdata_path = try std.fs.path.resolve(allocator, &[_][]const u8{ deecy_folder, path_config.userdata_path });
+        break :dir deecy_folder;
 
-        try std.Io.Dir.cwd().createDirPath(io, deecy_folder);
-        try std.Io.Dir.cwd().createDirPath(io, data_path);
-        try std.Io.Dir.cwd().createDirPath(io, userdata_path);
-    }
+        // data_path = try std.fs.path.resolve(allocator, &[_][]const u8{ deecy_folder, path_config.data_path });
+        // userdata_path = try std.fs.path.resolve(allocator, &[_][]const u8{ deecy_folder, path_config.userdata_path });
+
+        // try std.Io.Dir.createDirAbsolute(io, deecy_folder);
+        // try std.Io.Dir.createDirAbsolute(io, data_path);
+        // try std.Io.Dir.createDirAbsolute(io, userdata_path);
+
+        // root_dir = try std.Io.Dir.openDirAbsolute(io, deecy_folder, .{});
+        // data_dir = try std.Io.Dir.openDirAbsolute(io, get_data_path(), .{});
+        // userdata_dir = try std.Io.Dir.openDirAbsolute(io, get_userdata_path(), .{});
+    } else dir: {
+        const path_len = try std.process.executableDirPath(io, &path_buffer);
+        break :dir path_buffer[0..path_len];
+
+        // data_path = try std.fs.path.resolve(allocator, &[_][]const u8{ path, path_config.data_path });
+        // userdata_path = try std.fs.path.resolve(allocator, &[_][]const u8{ path, path_config.userdata_path });
+
+        // try root_dir.createDirPath(io, get_data_path());
+        // try root_dir.createDirPath(io, get_userdata_path());
+
+        // data_dir = try root_dir.openDir(io, get_data_path(), .{});
+        // userdata_dir = try root_dir.openDir(io, get_userdata_path(), .{});
+    };
+
+    root_dir = try std.Io.Dir.openDirAbsolute(io, deecy_folder, .{});
+    data_path = try std.fs.path.resolve(allocator, &[_][]const u8{ deecy_folder, path_config.data_path });
+    userdata_path = try std.fs.path.resolve(allocator, &[_][]const u8{ deecy_folder, path_config.userdata_path });
+
+    try std.Io.Dir.createDirAbsolute(io, deecy_folder, .default_dir);
+    try std.Io.Dir.createDirAbsolute(io, data_path, .default_dir);
+    try std.Io.Dir.createDirAbsolute(io, userdata_path, .default_dir);
+
+    root_dir = try std.Io.Dir.openDirAbsolute(io, deecy_folder, .{});
+    data_dir = try std.Io.Dir.openDirAbsolute(io, get_data_path(), .{});
+    userdata_dir = try std.Io.Dir.openDirAbsolute(io, get_userdata_path(), .{});
 }
 
-pub fn deinit(allocator: std.mem.Allocator) void {
+pub fn deinit(io: std.Io, allocator: std.mem.Allocator) void {
     if (path_config.use_appdata_dir) {
         allocator.free(data_path);
         allocator.free(userdata_path);
     }
+
+    userdata_dir.close(io);
+    data_dir.close(io);
+    root_dir.close(io);
 }
 
 /// Replaces invalid characters with underscores
@@ -39,16 +78,28 @@ pub fn safe_path(path: []u8) void {
     }
 }
 
+/// Absolute path to data folder.
 pub fn get_data_path() []const u8 {
-    if (path_config.use_appdata_dir)
-        return data_path;
-    return path_config.data_path;
+    return data_path;
 }
 
+/// Absolute path to userdata folder.
 pub fn get_userdata_path() []const u8 {
-    if (path_config.use_appdata_dir)
-        return userdata_path;
-    return path_config.userdata_path;
+    return userdata_path;
+}
+
+/// Root directory of saved files.
+///   Executable directory if not using appdata.
+pub fn root() std.Io.Dir {
+    return root_dir;
+}
+
+pub fn data() std.Io.Dir {
+    return data_dir;
+}
+
+pub fn userdata() std.Io.Dir {
+    return userdata_dir;
 }
 
 /// Caller owns the returned memory

--- a/src/dreamcast/maple.zig
+++ b/src/dreamcast/maple.zig
@@ -1,11 +1,7 @@
 const std = @import("std");
-const termcolor = @import("termcolor");
-
 const log = std.log.scoped(.maple);
 
-const DreamcastModule = @import("dreamcast.zig");
-const Dreamcast = DreamcastModule.Dreamcast;
-const Context = DreamcastModule.Context;
+const Dreamcast = @import("dreamcast.zig").Dreamcast;
 
 // Structure of a transfer:
 //   Instruction
@@ -168,7 +164,7 @@ const Peripheral = union(enum) {
         return switch (self.*) {
             inline .VMU, .VibrationPack => |*v| v.block_read(function, location.partition, location.block_num, location.phase, dest),
             else => s: {
-                log.err(termcolor.red("Unimplemented BlockRead for target: {t}"), .{self.tag()});
+                log.err("Unimplemented BlockRead for target: {t}", .{self.tag()});
                 break :s 0;
             },
         };
@@ -177,7 +173,7 @@ const Peripheral = union(enum) {
     pub fn block_write(self: *@This(), function: u32, location: BlockLocation, data: []const u32) u8 {
         switch (self.*) {
             inline .VMU, .VibrationPack => |*v| return v.block_write(function, location.partition, location.block_num, location.phase, data),
-            else => log.warn(termcolor.yellow("BlockWrite Unimplemented for target: {t}"), .{self.tag()}),
+            else => log.warn("BlockWrite Unimplemented for target: {t}", .{self.tag()}),
         }
         return 0;
     }
@@ -415,7 +411,7 @@ pub const MapleHost = struct {
                     idx += instr.transfer_length + 2;
                 },
                 .NOP, .RESET => {},
-                else => log.warn(termcolor.yellow("[Maple] Unimplemented pattern: {}. Ignoring it, hopefully the payload is empty :D"), .{instr.pattern}),
+                else => log.warn("Unimplemented pattern: {}. Ignoring it, hopefully the payload is empty :D", .{instr.pattern}),
             }
 
             if (instr.end_flag == 1)

--- a/src/dreamcast/maple.zig
+++ b/src/dreamcast/maple.zig
@@ -145,9 +145,9 @@ const Peripheral = union(enum) {
     VibrationPack: VibrationPack,
     Microphone: Microphone,
 
-    pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
+    pub fn deinit(self: *@This(), io: std.Io, allocator: std.mem.Allocator) void {
         switch (self.*) {
-            .VMU => |*v| v.deinit(allocator),
+            .VMU => |*v| v.deinit(io, allocator),
             .Microphone => |*m| m.deinit(),
             inline else => {},
         }
@@ -201,11 +201,11 @@ const EmulatedPort = struct {
     main: Peripheral,
     subperipherals: [5]?Peripheral = @splat(null),
 
-    pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
-        self.main.deinit(allocator);
+    pub fn deinit(self: *@This(), io: std.Io, allocator: std.mem.Allocator) void {
+        self.main.deinit(io, allocator);
         for (&self.subperipherals) |*sub| {
             if (sub.*) |*p|
-                p.deinit(allocator);
+                p.deinit(io, allocator);
         }
         self.subperipherals = @splat(null);
     }
@@ -363,9 +363,9 @@ pub const MaplePort = union(enum) {
     emulated: EmulatedPort,
     physical: struct { physical_port: u8 },
 
-    pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
+    pub fn deinit(self: *@This(), io: std.Io, allocator: std.mem.Allocator) void {
         switch (self.*) {
-            .emulated => |*e| e.deinit(allocator),
+            .emulated => |*e| e.deinit(io, allocator),
             else => {},
         }
     }
@@ -385,14 +385,10 @@ pub const MaplePort = union(enum) {
 pub const MapleHost = struct {
     ports: [4]MaplePort = @splat(.none),
 
-    _allocator: std.mem.Allocator,
+    pub const init: @This() = .{};
 
-    pub fn init(allocator: std.mem.Allocator) !MapleHost {
-        return .{ ._allocator = allocator };
-    }
-
-    pub fn deinit(self: *MapleHost) void {
-        for (&self.ports) |*port| port.deinit(self._allocator);
+    pub fn deinit(self: *@This(), io: std.Io, allocator: std.mem.Allocator) void {
+        for (&self.ports) |*port| port.deinit(io, allocator);
     }
 
     pub fn transfer(self: *MapleHost, dc: *Dreamcast, data: [*]u32) void {
@@ -432,8 +428,8 @@ pub const MapleHost = struct {
     // Not writing to disc after every single VMU write is not only wasteful,
     // it also make backups useless (a backup with half an update is useless).
     // VMU will also flush themselves on exit if needed.
-    pub fn flush_vmus(self: *@This()) void {
-        const now = std.Io.Clock.awake.now(Context.io).toSeconds();
+    pub fn flush_vmus(self: *@This(), io: std.Io) void {
+        const now = std.Io.Clock.awake.now(io).toSeconds();
         for (&self.ports) |*port| {
             switch (port.*) {
                 .emulated => |*e| {
@@ -443,7 +439,7 @@ pub const MapleHost = struct {
                                 .VMU => |*vmu| {
                                     if (vmu.last_unsaved_change) |last_unsaved_change| {
                                         if (now - last_unsaved_change > 5)
-                                            vmu.save();
+                                            vmu.save(io);
                                     }
                                 },
                                 else => {},

--- a/src/dreamcast/maple/vmu.zig
+++ b/src/dreamcast/maple/vmu.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const log = std.log.scoped(.maple);
 const termcolor = @import("termcolor");
 
-const Context = @import("../dreamcast.zig").Context;
+const Dreamcast = @import("../dreamcast.zig");
+const Context = Dreamcast.Context;
+const HostPaths = Dreamcast.HostPaths;
 const common = @import("../maple.zig");
 const FunctionCodesMask = common.FunctionCodesMask;
 const DeviceInfoPayload = common.DeviceInfoPayload;
@@ -119,10 +121,10 @@ pub fn init(allocator: std.mem.Allocator, backing_file_path: []const u8) !@This(
 
 fn load_or_init(self: *@This()) !void {
     if (std.fs.path.dirname(self.backing_file_path)) |dir|
-        try std.Io.Dir.cwd().createDirPath(Context.io, dir);
+        try HostPaths.root().createDirPath(Context.io, dir);
 
     log.info("Loading VMU from file '{s}'.", .{self.backing_file_path});
-    _ = std.Io.Dir.cwd().readFile(Context.io, self.backing_file_path, @as([*]u8, @ptrCast(self.blocks.ptr))[0 .. self.blocks.len * BlockSize]) catch {
+    _ = HostPaths.root().readFile(Context.io, self.backing_file_path, @as([*]u8, @ptrCast(self.blocks.ptr))[0 .. self.blocks.len * BlockSize]) catch {
         log.info("  Not found: Initializing new VMU at '{s}'.", .{self.backing_file_path});
         // FIXME: Something's wrong here. I'm not initiliazing it properly.
         //        Switching to a dumb copy of a freshly formatted VMU by the bios, until I understand it better.
@@ -186,7 +188,7 @@ pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
 pub fn save(self: *@This()) void {
     self.save_backup();
 
-    std.Io.Dir.cwd().writeFile(
+    HostPaths.root().writeFile(
         Context.io,
         .{
             .sub_path = self.backing_file_path,
@@ -208,7 +210,7 @@ pub fn save_backup(self: *const @This()) void {
         log.err("Failed to format backup filename: {t}", .{err});
         return;
     };
-    std.Io.Dir.cwd().copyFile(self.backing_file_path, std.Io.Dir.cwd(), backup_file_path, Context.io, .{ .make_path = false, .replace = true }) catch |err| {
+    HostPaths.root().copyFile(self.backing_file_path, HostPaths.root(), backup_file_path, Context.io, .{ .make_path = false, .replace = true }) catch |err| {
         log.err("Failed to backup VMU file '{s}': {t}", .{ backup_file_path, err });
     };
 }

--- a/src/dreamcast/maple/vmu.zig
+++ b/src/dreamcast/maple/vmu.zig
@@ -4,7 +4,6 @@ const termcolor = @import("termcolor");
 
 const Dreamcast = @import("../dreamcast.zig");
 const Context = Dreamcast.Context;
-const HostPaths = Dreamcast.HostPaths;
 const common = @import("../maple.zig");
 const FunctionCodesMask = common.FunctionCodesMask;
 const DeviceInfoPayload = common.DeviceInfoPayload;
@@ -110,21 +109,21 @@ last_unsaved_change: ?i64 = null,
 on_screen_update: ?struct { function: *const fn (userdata: ?*anyopaque, data: [*]const u8) void, userdata: ?*anyopaque } = null,
 on_timer_alarm: ?struct { function: *const fn (userdata: ?*anyopaque, alw0: u8, ald0: u8, alw1: u8, ald1: u8) void, userdata: ?*anyopaque } = null,
 
-pub fn init(allocator: std.mem.Allocator, backing_file_path: []const u8) !@This() {
+pub fn init(io: std.Io, allocator: std.mem.Allocator, backing_file_path: []const u8) !@This() {
     var vmu: @This() = .{
         .backing_file_path = try allocator.dupe(u8, backing_file_path),
         .blocks = try allocator.alloc([BlockSize]u8, 0x100),
     };
-    try vmu.load_or_init();
+    try vmu.load_or_init(io);
     return vmu;
 }
 
-fn load_or_init(self: *@This()) !void {
+fn load_or_init(self: *@This(), io: std.Io) !void {
     if (std.fs.path.dirname(self.backing_file_path)) |dir|
-        try HostPaths.root().createDirPath(Context.io, dir);
+        try std.Io.Dir.cwd().createDirPath(io, dir);
 
     log.info("Loading VMU from file '{s}'.", .{self.backing_file_path});
-    _ = HostPaths.root().readFile(Context.io, self.backing_file_path, @as([*]u8, @ptrCast(self.blocks.ptr))[0 .. self.blocks.len * BlockSize]) catch {
+    _ = std.Io.Dir.cwd().readFile(io, self.backing_file_path, @as([*]u8, @ptrCast(self.blocks.ptr))[0 .. self.blocks.len * BlockSize]) catch {
         log.info("  Not found: Initializing new VMU at '{s}'.", .{self.backing_file_path});
         // FIXME: Something's wrong here. I'm not initiliazing it properly.
         //        Switching to a dumb copy of a freshly formatted VMU by the bios, until I understand it better.
@@ -174,22 +173,22 @@ fn load_or_init(self: *@This()) !void {
             fat_entries[FATBlock] = FATValue.DataEnd;
             fat_entries[SystemBlock] = FATValue.DataEnd; // Marks the system area block.
         }
-        self.last_unsaved_change = std.Io.Clock.awake.now(Context.io).toSeconds();
+        self.last_unsaved_change = std.Io.Clock.awake.now(io).toSeconds();
     };
 }
 
-pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
+pub fn deinit(self: *@This(), io: std.Io, allocator: std.mem.Allocator) void {
     if (self.last_unsaved_change != null)
-        self.save();
+        self.save(io);
     allocator.free(self.blocks);
     allocator.free(self.backing_file_path);
 }
 
-pub fn save(self: *@This()) void {
-    self.save_backup();
+pub fn save(self: *@This(), io: std.Io) void {
+    self.save_backup(io);
 
-    HostPaths.root().writeFile(
-        Context.io,
+    std.Io.Dir.cwd().writeFile(
+        io,
         .{
             .sub_path = self.backing_file_path,
             .data = @as([*]u8, @ptrCast(self.blocks.ptr))[0 .. self.blocks.len * BlockSize],
@@ -204,13 +203,13 @@ pub fn save(self: *@This()) void {
     self.last_unsaved_change = null;
 }
 
-pub fn save_backup(self: *const @This()) void {
+pub fn save_backup(self: *const @This(), io: std.Io) void {
     var buf: [256]u8 = @splat(0);
     const backup_file_path = std.fmt.bufPrint(&buf, "{s}.bak", .{self.backing_file_path}) catch |err| {
         log.err("Failed to format backup filename: {t}", .{err});
         return;
     };
-    HostPaths.root().copyFile(self.backing_file_path, HostPaths.root(), backup_file_path, Context.io, .{ .make_path = false, .replace = true }) catch |err| {
+    std.Io.Dir.cwd().copyFile(self.backing_file_path, std.Io.Dir.cwd(), backup_file_path, io, .{ .make_path = false, .replace = true }) catch |err| {
         log.err("Failed to backup VMU file '{s}': {t}", .{ backup_file_path, err });
     };
 }

--- a/src/dreamcast/maple/vmu.zig
+++ b/src/dreamcast/maple/vmu.zig
@@ -173,7 +173,7 @@ fn load_or_init(self: *@This(), io: std.Io) !void {
             fat_entries[FATBlock] = FATValue.DataEnd;
             fat_entries[SystemBlock] = FATValue.DataEnd; // Marks the system area block.
         }
-        self.last_unsaved_change = std.Io.Clock.awake.now(io).toSeconds();
+        self.last_unsaved_change = std.Io.Clock.awake.now(Context.io).toSeconds(); // NOTE: Using Context.io here for consistency.
     };
 }
 

--- a/src/host_paths.zig
+++ b/src/host_paths.zig
@@ -7,7 +7,8 @@ var userdata_dir: std.Io.Dir = undefined;
 
 pub fn init(io: std.Io, allocator: std.mem.Allocator, environ: std.process.Environ.Map) !void {
     var path_buffer: [std.fs.max_path_bytes]u8 = undefined;
-    const deecy_folder = if (path_config.use_appdata_dir) dir: {
+
+    const root_path = if (path_config.use_appdata_dir) dir: {
         const app_data_dir = try known_folders.getPath(io, allocator, environ, .local_configuration) orelse {
             std.log.warn("No known 'local_configuration' folder.", .{});
             return error.MissingKnownFolder;
@@ -16,59 +17,45 @@ pub fn init(io: std.Io, allocator: std.mem.Allocator, environ: std.process.Envir
 
         const deecy_folder = try std.fs.path.join(allocator, &[_][]const u8{ app_data_dir, "Deecy" });
         defer allocator.free(deecy_folder);
-        std.log.info("Using App data folder as '{s}'", .{deecy_folder});
 
         break :dir deecy_folder;
-
-        // data_path = try std.fs.path.resolve(allocator, &[_][]const u8{ deecy_folder, path_config.data_path });
-        // userdata_path = try std.fs.path.resolve(allocator, &[_][]const u8{ deecy_folder, path_config.userdata_path });
-
-        // try std.Io.Dir.createDirAbsolute(io, deecy_folder);
-        // try std.Io.Dir.createDirAbsolute(io, data_path);
-        // try std.Io.Dir.createDirAbsolute(io, userdata_path);
-
-        // root_dir = try std.Io.Dir.openDirAbsolute(io, deecy_folder, .{});
-        // data_dir = try std.Io.Dir.openDirAbsolute(io, get_data_path(), .{});
-        // userdata_dir = try std.Io.Dir.openDirAbsolute(io, get_userdata_path(), .{});
     } else dir: {
         const path_len = try std.process.executableDirPath(io, &path_buffer);
         break :dir path_buffer[0..path_len];
-
-        // data_path = try std.fs.path.resolve(allocator, &[_][]const u8{ path, path_config.data_path });
-        // userdata_path = try std.fs.path.resolve(allocator, &[_][]const u8{ path, path_config.userdata_path });
-
-        // try root_dir.createDirPath(io, get_data_path());
-        // try root_dir.createDirPath(io, get_userdata_path());
-
-        // data_dir = try root_dir.openDir(io, get_data_path(), .{});
-        // userdata_dir = try root_dir.openDir(io, get_userdata_path(), .{});
     };
+    std.log.info("Using directory '{s}'", .{root_path});
 
-    root_dir = try std.Io.Dir.openDirAbsolute(io, deecy_folder, .{});
-    data_path = try std.fs.path.resolve(allocator, &[_][]const u8{ deecy_folder, path_config.data_path });
-    userdata_path = try std.fs.path.resolve(allocator, &[_][]const u8{ deecy_folder, path_config.userdata_path });
+    root_dir = try std.Io.Dir.openDirAbsolute(io, root_path, .{});
+    data_path = try std.fs.path.resolve(allocator, &[_][]const u8{ root_path, path_config.data_path });
+    userdata_path = try std.fs.path.resolve(allocator, &[_][]const u8{ root_path, path_config.userdata_path });
 
-    try std.Io.Dir.createDirAbsolute(io, deecy_folder, .default_dir);
-    try std.Io.Dir.createDirAbsolute(io, data_path, .default_dir);
-    try std.Io.Dir.createDirAbsolute(io, userdata_path, .default_dir);
+    try ensure_dir(io, root_path);
+    try ensure_dir(io, data_path);
+    try ensure_dir(io, userdata_path);
 
-    root_dir = try std.Io.Dir.openDirAbsolute(io, deecy_folder, .{});
+    root_dir = try std.Io.Dir.openDirAbsolute(io, root_path, .{});
     data_dir = try std.Io.Dir.openDirAbsolute(io, get_data_path(), .{});
     userdata_dir = try std.Io.Dir.openDirAbsolute(io, get_userdata_path(), .{});
 }
 
-pub fn deinit(io: std.Io, allocator: std.mem.Allocator) void {
-    if (path_config.use_appdata_dir) {
-        allocator.free(data_path);
-        allocator.free(userdata_path);
-    }
+/// Make sure `path` exists by calling createDirAbsolute. Does not return an error if `path` already exists.
+fn ensure_dir(io: std.Io, path: []const u8) !void {
+    std.Io.Dir.createDirAbsolute(io, path, .default_dir) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => |e| return e,
+    };
+}
 
+pub fn deinit(io: std.Io, allocator: std.mem.Allocator) void {
     userdata_dir.close(io);
     data_dir.close(io);
     root_dir.close(io);
+
+    allocator.free(data_path);
+    allocator.free(userdata_path);
 }
 
-/// Replaces invalid characters with underscores
+/// Replaces invalid characters with underscores in place.
 pub fn safe_path(path: []u8) void {
     for (path) |*c| {
         switch (c.*) {
@@ -102,13 +89,21 @@ pub fn userdata() std.Io.Dir {
     return userdata_dir;
 }
 
-/// Caller owns the returned memory
-pub fn userdata_game_directory(allocator: std.mem.Allocator, uid: ProductUID) ![]const u8 {
+/// Caller owns the returned memory.
+pub fn game_directory_path(allocator: std.mem.Allocator, uid: ProductUID) ![]const u8 {
     const folder_name = try std.fmt.allocPrint(allocator, "{s}[{s}]", .{ uid.name, uid.id });
     safe_path(folder_name);
     defer allocator.free(folder_name);
     const path = try std.fs.path.join(allocator, &[_][]const u8{ get_userdata_path(), folder_name });
     return path;
+}
+
+/// Caller should `close` the returned directory.
+pub fn game_directory(io: std.Io, allocator: std.mem.Allocator, uid: ProductUID) !std.Io.Dir {
+    const path = try game_directory_path(allocator, uid);
+    defer allocator.free(path);
+    try ensure_dir(io, path);
+    return std.Io.Dir.openDirAbsolute(io, path, .{});
 }
 
 const std = @import("std");

--- a/src/host_paths.zig
+++ b/src/host_paths.zig
@@ -18,10 +18,8 @@ pub fn init(io: std.Io, allocator: std.mem.Allocator, environ: std.process.Envir
         };
         defer allocator.free(app_data_dir);
 
-        const deecy_folder = try std.fs.path.join(allocator, &[_][]const u8{ app_data_dir, "Deecy" });
-        defer allocator.free(deecy_folder);
-
-        break :dir deecy_folder;
+        var fixed_allocator = std.heap.FixedBufferAllocator.init(&path_buffer);
+        break :dir try std.fs.path.join(fixed_allocator.allocator(), &[_][]const u8{ app_data_dir, "Deecy" });
     } else dir: {
         const path_len = try std.process.executableDirPath(io, &path_buffer);
         break :dir path_buffer[0..path_len];

--- a/src/host_paths.zig
+++ b/src/host_paths.zig
@@ -1,11 +1,14 @@
-var data_path: []const u8 = "";
-var userdata_path: []const u8 = "";
+var context: ?struct {
+    data_path: []const u8,
+    userdata_path: []const u8,
 
-var root_dir: std.Io.Dir = undefined;
-var data_dir: std.Io.Dir = undefined;
-var userdata_dir: std.Io.Dir = undefined;
+    root_dir: std.Io.Dir,
+    data_dir: std.Io.Dir,
+    userdata_dir: std.Io.Dir,
+} = null;
 
 pub fn init(io: std.Io, allocator: std.mem.Allocator, environ: std.process.Environ.Map) !void {
+    std.debug.assert(context == null);
     var path_buffer: [std.fs.max_path_bytes]u8 = undefined;
 
     const root_path = if (path_config.use_appdata_dir) dir: {
@@ -25,17 +28,20 @@ pub fn init(io: std.Io, allocator: std.mem.Allocator, environ: std.process.Envir
     };
     std.log.info("Using directory '{s}'", .{root_path});
 
-    root_dir = try std.Io.Dir.openDirAbsolute(io, root_path, .{});
-    data_path = try std.fs.path.resolve(allocator, &[_][]const u8{ root_path, path_config.data_path });
-    userdata_path = try std.fs.path.resolve(allocator, &[_][]const u8{ root_path, path_config.userdata_path });
+    const data_path = try std.fs.path.resolve(allocator, &[_][]const u8{ root_path, path_config.data_path });
+    const userdata_path = try std.fs.path.resolve(allocator, &[_][]const u8{ root_path, path_config.userdata_path });
 
     try ensure_dir(io, root_path);
     try ensure_dir(io, data_path);
     try ensure_dir(io, userdata_path);
 
-    root_dir = try std.Io.Dir.openDirAbsolute(io, root_path, .{});
-    data_dir = try std.Io.Dir.openDirAbsolute(io, get_data_path(), .{});
-    userdata_dir = try std.Io.Dir.openDirAbsolute(io, get_userdata_path(), .{});
+    context = .{
+        .root_dir = try std.Io.Dir.openDirAbsolute(io, root_path, .{}),
+        .data_dir = try std.Io.Dir.openDirAbsolute(io, data_path, .{}),
+        .userdata_dir = try std.Io.Dir.openDirAbsolute(io, userdata_path, .{}),
+        .data_path = data_path,
+        .userdata_path = userdata_path,
+    };
 }
 
 /// Make sure `path` exists by calling createDirAbsolute. Does not return an error if `path` already exists.
@@ -47,12 +53,14 @@ fn ensure_dir(io: std.Io, path: []const u8) !void {
 }
 
 pub fn deinit(io: std.Io, allocator: std.mem.Allocator) void {
-    userdata_dir.close(io);
-    data_dir.close(io);
-    root_dir.close(io);
-
-    allocator.free(data_path);
-    allocator.free(userdata_path);
+    if (context) |ctx| {
+        ctx.userdata_dir.close(io);
+        ctx.data_dir.close(io);
+        ctx.root_dir.close(io);
+        allocator.free(ctx.userdata_path);
+        allocator.free(ctx.data_path);
+    }
+    context = null;
 }
 
 /// Replaces invalid characters with underscores in place.
@@ -67,26 +75,26 @@ pub fn safe_path(path: []u8) void {
 
 /// Absolute path to data folder.
 pub fn get_data_path() []const u8 {
-    return data_path;
+    return context.?.data_path;
 }
 
 /// Absolute path to userdata folder.
 pub fn get_userdata_path() []const u8 {
-    return userdata_path;
+    return context.?.userdata_path;
 }
 
 /// Root directory of saved files.
 ///   Executable directory if not using appdata.
 pub fn root() std.Io.Dir {
-    return root_dir;
+    return context.?.root_dir;
 }
 
 pub fn data() std.Io.Dir {
-    return data_dir;
+    return context.?.data_dir;
 }
 
 pub fn userdata() std.Io.Dir {
-    return userdata_dir;
+    return context.?.userdata_dir;
 }
 
 /// Caller owns the returned memory.

--- a/src/log_file.zig
+++ b/src/log_file.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const HostPaths = @import("dreamcast").HostPaths;
+const host_paths = @import("host_paths.zig");
 
 pub var writer: *std.Io.Writer = undefined;
 
@@ -12,15 +12,13 @@ var _opened: bool = false;
 var _io: std.Io = undefined;
 
 /// Noop if already open
-pub fn open(allocator: std.mem.Allocator, io: std.Io) !void {
+pub fn open(io: std.Io) !void {
     if (!opened()) {
         _io = io;
 
         mutex.lockUncancelable(io);
         defer mutex.unlock(io);
-        const path = try get_path(allocator);
-        defer allocator.free(path);
-        file = try HostPaths.root().createFile(io, path, .{});
+        file = try host_paths.userdata().createFile(io, "deecy.log", .{});
         file_writer = file.writer(io, &buffer);
         writer = &file_writer.interface;
         _opened = true;
@@ -52,6 +50,7 @@ pub fn unlock() void {
     if (opened()) mutex.unlock(_io);
 }
 
-pub fn get_path(allocator: std.mem.Allocator) ![]const u8 {
-    return std.fs.path.join(allocator, &.{ HostPaths.get_userdata_path(), "deecy.log" });
+/// Caller owns the returned memory.
+pub fn path(allocator: std.mem.Allocator) ![]const u8 {
+    return std.fs.path.join(allocator, &.{ host_paths.get_userdata_path(), "deecy.log" });
 }

--- a/src/log_file.zig
+++ b/src/log_file.zig
@@ -20,7 +20,7 @@ pub fn open(allocator: std.mem.Allocator, io: std.Io) !void {
         defer mutex.unlock(io);
         const path = try get_path(allocator);
         defer allocator.free(path);
-        file = try std.Io.Dir.cwd().createFile(io, path, .{});
+        file = try HostPaths.root().createFile(io, path, .{});
         file_writer = file.writer(io, &buffer);
         writer = &file_writer.interface;
         _opened = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,6 +6,7 @@ const termcolor = @import("termcolor");
 const custom_log = @import("custom_log.zig");
 
 const DreamcastModule = @import("dreamcast");
+const host_paths = @import("host_paths.zig");
 const Holly = DreamcastModule.HollyModule;
 const MapleModule = DreamcastModule.Maple;
 const PreciseSleep = @import("precise_sleep.zig");
@@ -59,11 +60,11 @@ pub fn main(init: std.process.Init) !void {
     const io = init.io;
     const allocator = init.gpa;
 
-    custom_log.init(io, allocator);
+    custom_log.init(io);
     defer custom_log.deinit();
 
-    try DreamcastModule.HostPaths.init(io, allocator, init.environ_map.*);
-    defer DreamcastModule.HostPaths.deinit(io, allocator);
+    try host_paths.init(io, allocator, init.environ_map.*);
+    defer host_paths.deinit(io, allocator);
 
     defer DreamcastModule.SH4Module.SCIF.deinit(io);
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -63,7 +63,7 @@ pub fn main(init: std.process.Init) !void {
     defer custom_log.deinit();
 
     try DreamcastModule.HostPaths.init(io, allocator, init.environ_map.*);
-    defer DreamcastModule.HostPaths.deinit(allocator);
+    defer DreamcastModule.HostPaths.deinit(io, allocator);
 
     defer DreamcastModule.SH4Module.SCIF.deinit(io);
 

--- a/src/pipeline_cache.zig
+++ b/src/pipeline_cache.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 
-const HostPaths = @import("dreamcast").HostPaths;
 const Deecy = @import("deecy.zig");
+const host_paths = Deecy.host_paths;
 
 const log = std.log.scoped(.pipeline_cache);
 
@@ -35,11 +35,11 @@ fn load_pipeline_cache_impl(allocator: std.mem.Allocator, key: []const u8, value
     var name_buf: [64]u8 = undefined;
     const hex_name = try cache_file_name(key, &name_buf);
 
-    const userdata_path = HostPaths.get_userdata_path();
+    const userdata_path = host_paths.get_userdata_path();
     const path = try std.fs.path.join(allocator, &.{ userdata_path, CacheDir, hex_name });
     defer allocator.free(path);
 
-    const file = try HostPaths.root().openFile(io, path, .{});
+    const file = try host_paths.root().openFile(io, path, .{});
     defer file.close(io);
 
     const size = (try file.stat(io)).size;
@@ -73,12 +73,12 @@ fn store_pipeline_cache_impl(allocator: std.mem.Allocator, key: []const u8, valu
     var name_buf: [64]u8 = undefined;
     const hex_name = try cache_file_name(key, &name_buf);
 
-    const path = try std.fs.path.join(allocator, &.{ HostPaths.get_userdata_path(), CacheDir, hex_name });
+    const path = try std.fs.path.join(allocator, &.{ host_paths.get_userdata_path(), CacheDir, hex_name });
     defer allocator.free(path);
 
-    if (std.fs.path.dirname(path)) |dir| try HostPaths.root().createDirPath(io, dir);
+    if (std.fs.path.dirname(path)) |dir| try host_paths.root().createDirPath(io, dir);
 
-    try HostPaths.root().writeFile(io, .{
+    try host_paths.root().writeFile(io, .{
         .sub_path = path,
         .data = value,
         .flags = .{ .truncate = true },
@@ -89,10 +89,10 @@ pub fn clear(allocator: std.mem.Allocator) !void {
     var threaded: std.Io.Threaded = .init_single_threaded;
     const io = threaded.io();
 
-    const userdata_path = HostPaths.get_userdata_path();
+    const userdata_path = host_paths.get_userdata_path();
     const dir = try std.fs.path.join(allocator, &.{ userdata_path, CacheDir });
     defer allocator.free(dir);
     log.warn("Deleting '{s}'", .{dir});
-    try HostPaths.root().deleteTree(io, dir);
-    try HostPaths.root().createDirPath(io, dir);
+    try host_paths.root().deleteTree(io, dir);
+    try host_paths.root().createDirPath(io, dir);
 }

--- a/src/pipeline_cache.zig
+++ b/src/pipeline_cache.zig
@@ -39,7 +39,7 @@ fn load_pipeline_cache_impl(allocator: std.mem.Allocator, key: []const u8, value
     const path = try std.fs.path.join(allocator, &.{ userdata_path, CacheDir, hex_name });
     defer allocator.free(path);
 
-    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    const file = try HostPaths.root().openFile(io, path, .{});
     defer file.close(io);
 
     const size = (try file.stat(io)).size;
@@ -76,9 +76,9 @@ fn store_pipeline_cache_impl(allocator: std.mem.Allocator, key: []const u8, valu
     const path = try std.fs.path.join(allocator, &.{ HostPaths.get_userdata_path(), CacheDir, hex_name });
     defer allocator.free(path);
 
-    if (std.fs.path.dirname(path)) |dir| try std.Io.Dir.cwd().createDirPath(io, dir);
+    if (std.fs.path.dirname(path)) |dir| try HostPaths.root().createDirPath(io, dir);
 
-    try std.Io.Dir.cwd().writeFile(io, .{
+    try HostPaths.root().writeFile(io, .{
         .sub_path = path,
         .data = value,
         .flags = .{ .truncate = true },
@@ -93,6 +93,6 @@ pub fn clear(allocator: std.mem.Allocator) !void {
     const dir = try std.fs.path.join(allocator, &.{ userdata_path, CacheDir });
     defer allocator.free(dir);
     log.warn("Deleting '{s}'", .{dir});
-    try std.Io.Dir.cwd().deleteTree(io, dir);
-    try std.Io.Dir.cwd().createDirPath(io, dir);
+    try HostPaths.root().deleteTree(io, dir);
+    try HostPaths.root().createDirPath(io, dir);
 }

--- a/src/ui/shortcuts.zig
+++ b/src/ui/shortcuts.zig
@@ -3,7 +3,7 @@ const zglfw = @import("zglfw");
 
 const termcolor = @import("termcolor");
 const Deecy = @import("../deecy.zig");
-const HostPaths = @import("dreamcast").HostPaths;
+const host_paths = Deecy.host_paths;
 
 const log = std.log.scoped(.deecy);
 
@@ -228,7 +228,7 @@ fn serialize(self: @This(), allocator: std.mem.Allocator, io: std.Io) !void {
     const config_path = try get_config_path(allocator);
     defer allocator.free(config_path);
 
-    var config_file = try HostPaths.root().createFile(io, config_path, .{});
+    var config_file = try host_paths.root().createFile(io, config_path, .{});
     defer config_file.close(io);
 
     const buffer = try allocator.alloc(u8, 8192);
@@ -242,7 +242,7 @@ fn deserialize(self: *@This(), allocator: std.mem.Allocator, io: std.Io) !void {
     const config_path = try get_config_path(allocator);
     defer allocator.free(config_path);
 
-    const data = try HostPaths.root().readFileAllocOptions(io, config_path, allocator, .limited(32 * 1024 * 1024), .@"8", 0);
+    const data = try host_paths.root().readFileAllocOptions(io, config_path, allocator, .limited(32 * 1024 * 1024), .@"8", 0);
     defer allocator.free(data);
 
     var diagnostics: std.zon.parse.Diagnostics = .{};
@@ -260,7 +260,7 @@ fn deserialize(self: *@This(), allocator: std.mem.Allocator, io: std.Io) !void {
 }
 
 fn get_config_path(allocator: std.mem.Allocator) ![]const u8 {
-    return try std.fs.path.join(allocator, &[_][]const u8{ HostPaths.get_userdata_path(), "shortcuts.zon" });
+    return try std.fs.path.join(allocator, &[_][]const u8{ host_paths.get_userdata_path(), "shortcuts.zon" });
 }
 
 fn get_action(name: Action.Name) Action {

--- a/src/ui/shortcuts.zig
+++ b/src/ui/shortcuts.zig
@@ -228,7 +228,7 @@ fn serialize(self: @This(), allocator: std.mem.Allocator, io: std.Io) !void {
     const config_path = try get_config_path(allocator);
     defer allocator.free(config_path);
 
-    var config_file = try std.Io.Dir.cwd().createFile(io, config_path, .{});
+    var config_file = try HostPaths.root().createFile(io, config_path, .{});
     defer config_file.close(io);
 
     const buffer = try allocator.alloc(u8, 8192);
@@ -242,7 +242,7 @@ fn deserialize(self: *@This(), allocator: std.mem.Allocator, io: std.Io) !void {
     const config_path = try get_config_path(allocator);
     defer allocator.free(config_path);
 
-    const data = try std.Io.Dir.cwd().readFileAllocOptions(io, config_path, allocator, .limited(32 * 1024 * 1024), .@"8", 0);
+    const data = try HostPaths.root().readFileAllocOptions(io, config_path, allocator, .limited(32 * 1024 * 1024), .@"8", 0);
     defer allocator.free(data);
 
     var diagnostics: std.zon.parse.Diagnostics = .{};

--- a/test/interpreter_perf.zig
+++ b/test/interpreter_perf.zig
@@ -32,11 +32,10 @@ pub const SaveStateHeader = extern struct {
 };
 
 pub fn load_state(dc: *Dreamcast, io: std.Io, path: []const u8) !void {
-    const file = try HostPaths.root().readFileAllocOptions(io, path, dc._allocator, .limited(32 * 1024 * 1024), .@"8", null);
+    const file = try std.Io.Dir.cwd().readFileAllocOptions(io, path, dc._allocator, .limited(32 * 1024 * 1024), .@"8", null);
     defer dc._allocator.free(file);
 
     const header = std.mem.bytesToValue(SaveStateHeader, file[0..@sizeOf(SaveStateHeader)]);
-    try header.validate();
     try header.validate();
 
     const compressed = file[@sizeOf(SaveStateHeader)..];
@@ -67,8 +66,15 @@ pub fn main(init: std.process.Init) !void {
 
     _ = args.skip();
 
+    const exe_path = try std.process.executableDirPathAlloc(io, allocator);
+    defer allocator.free(exe_path);
+    const boot_rom_path = try std.fs.path.join(allocator, &[_][]const u8{ exe_path, "data/dc_boot.bin" });
+    defer allocator.free(boot_rom_path);
+    const flash_path = try std.fs.path.join(allocator, &[_][]const u8{ exe_path, "data/dc_flash.bin" });
+    defer allocator.free(flash_path);
+
     while (args.next()) |game| {
-        var dc = try Dreamcast.create(allocator, io);
+        var dc = try Dreamcast.create(allocator, io, boot_rom_path);
         defer {
             dc.deinit();
             allocator.destroy(dc);
@@ -77,6 +83,7 @@ pub fn main(init: std.process.Init) !void {
         const save_state_path = args.next().?;
 
         dc.gdrom.disc = try .init(allocator, io, game);
+        try dc.load_flash(io, flash_path, dc.gdrom.disc.?.get_region(), .{});
         try load_state(dc, io, save_state_path);
         const start = std.Io.Timestamp.now(io, .awake);
         var cycles: u64 = 0;

--- a/test/interpreter_perf.zig
+++ b/test/interpreter_perf.zig
@@ -32,7 +32,7 @@ pub const SaveStateHeader = extern struct {
 };
 
 pub fn load_state(dc: *Dreamcast, io: std.Io, path: []const u8) !void {
-    const file = try std.Io.Dir.cwd().readFileAllocOptions(io, path, dc._allocator, .limited(32 * 1024 * 1024), .@"8", null);
+    const file = try HostPaths.root().readFileAllocOptions(io, path, dc._allocator, .limited(32 * 1024 * 1024), .@"8", null);
     defer dc._allocator.free(file);
 
     const header = std.mem.bytesToValue(SaveStateHeader, file[0..@sizeOf(SaveStateHeader)]);

--- a/test/jit_perf.zig
+++ b/test/jit_perf.zig
@@ -32,7 +32,7 @@ pub const SaveStateHeader = extern struct {
 };
 
 pub fn load_state(dc: *Dreamcast, io: std.Io, path: []const u8) !void {
-    const file = try HostPaths.root().readFileAllocOptions(io, path, dc._allocator, .limited(32 * 1024 * 1024), .@"8", null);
+    const file = try std.Io.Dir.cwd().readFileAllocOptions(io, path, dc._allocator, .limited(32 * 1024 * 1024), .@"8", null);
     defer dc._allocator.free(file);
 
     const header = std.mem.bytesToValue(SaveStateHeader, file[0..@sizeOf(SaveStateHeader)]);
@@ -54,16 +54,23 @@ pub fn load_state(dc: *Dreamcast, io: std.Io, path: []const u8) !void {
 
 // Expects pairs of game path and save state path as arguments
 pub fn main(init: std.process.Init) !void {
-    var cycles_target: u64 = 10 * 200_000_000;
-    var total_time: i64 = 0;
-
     var allocator = init.gpa;
     const io = init.io;
+
+    var cycles_target: u64 = 10 * 200_000_000;
+    var total_time: i64 = 0;
 
     var args = try init.minimal.args.iterateAllocator(allocator);
     defer args.deinit();
 
     _ = args.skip();
+
+    const exe_path = try std.process.executableDirPathAlloc(io, allocator);
+    defer allocator.free(exe_path);
+    const boot_rom_path = try std.fs.path.join(allocator, &[_][]const u8{ exe_path, "data/dc_boot.bin" });
+    defer allocator.free(boot_rom_path);
+    const flash_path = try std.fs.path.join(allocator, &[_][]const u8{ exe_path, "data/dc_flash.bin" });
+    defer allocator.free(flash_path);
 
     while (args.next()) |game| {
         if (std.mem.startsWith(u8, game, "-")) {
@@ -77,7 +84,8 @@ pub fn main(init: std.process.Init) !void {
             continue;
         }
 
-        var dc = try Dreamcast.create(allocator, io);
+        var dc = try Dreamcast.create(allocator, io, boot_rom_path);
+
         defer {
             dc.deinit();
             allocator.destroy(dc);
@@ -86,6 +94,7 @@ pub fn main(init: std.process.Init) !void {
         const save_state_path = args.next().?;
 
         dc.gdrom.disc = try .init(allocator, io, game);
+        try dc.load_flash(io, flash_path, dc.gdrom.disc.?.get_region(), .{});
         try load_state(dc, io, save_state_path);
         const start = std.Io.Timestamp.now(io, .awake);
         var cycles: u64 = 0;

--- a/test/jit_perf.zig
+++ b/test/jit_perf.zig
@@ -32,7 +32,7 @@ pub const SaveStateHeader = extern struct {
 };
 
 pub fn load_state(dc: *Dreamcast, io: std.Io, path: []const u8) !void {
-    const file = try std.Io.Dir.cwd().readFileAllocOptions(io, path, dc._allocator, .limited(32 * 1024 * 1024), .@"8", null);
+    const file = try HostPaths.root().readFileAllocOptions(io, path, dc._allocator, .limited(32 * 1024 * 1024), .@"8", null);
     defer dc._allocator.free(file);
 
     const header = std.mem.bytesToValue(SaveStateHeader, file[0..@sizeOf(SaveStateHeader)]);


### PR DESCRIPTION
Make all paths relative to the executable rather than the current working directory (unless using `known_folders`).

Allows launching the emulator from anywhere and still find the `data/` directory, and always use the same `userdata/`.